### PR TITLE
BUG: Link OpenCL library in `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,3 +64,5 @@ else()
   set(ITK_DIR ${CMAKE_BINARY_DIR})
   itk_module_impl()
 endif()
+
+target_link_libraries(VkFFTBackend PUBLIC ${OpenCL_LIBRARY})


### PR DESCRIPTION
Resolves cross-platform linking failures in `build-test-cxx` CI.

Partially resolves [Issue 8](https://github.com/InsightSoftwareConsortium/ITKVkFFTBackend/issues/8). Will revisit `build-<platform>-python-packages` failures in a subsequent PR.