### PR TITLE
BUG: Enable Testing CI

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,19 +13,19 @@ CreateTestDriver(VkFFTBackend
   "${VkFFTBackendTests}"
   )
 
-# itk_add_test(NAME itkVkComplexToComplexFFTImageFilterTest
-#   COMMAND VkFFTBackendTestDriver
-#     --compare
-#     DATA{Baseline/itkVkComplexToComplexFFTImageFilterTestOutput.mha}
-#     ${ITK_TEST_OUTPUT_DIR}/itkVkComplexToComplexFFTImageFilterTestOutput.mha
-#   itkVkComplexToComplexFFTImageFilterTest
-#     ${ITK_TEST_OUTPUT_DIR}/itkVkComplexToComplexFFTImageFilterTestOutput.mha
-#   )
+ itk_add_test(NAME itkVkComplexToComplexFFTImageFilterTest
+   COMMAND VkFFTBackendTestDriver
+     --compare
+     DATA{Baseline/itkVkComplexToComplexFFTImageFilterTestOutput.mha}
+     ${ITK_TEST_OUTPUT_DIR}/itkVkComplexToComplexFFTImageFilterTestOutput.mha
+   itkVkComplexToComplexFFTImageFilterTest
+     ${ITK_TEST_OUTPUT_DIR}/itkVkComplexToComplexFFTImageFilterTestOutput.mha
+   )
 
-# itk_add_test(NAME itkVkForwardInverseFFTImageFilterTest
-#   COMMAND VkFFTBackendTestDriver itkVkForwardInverseFFTImageFilterTest
-#   )
+ itk_add_test(NAME itkVkForwardInverseFFTImageFilterTest
+   COMMAND VkFFTBackendTestDriver itkVkForwardInverseFFTImageFilterTest
+   )
 
-# itk_add_test(NAME itkVkHalfHermitianFFTImageFilterTest
-#   COMMAND VkFFTBackendTestDriver itkVkHalfHermitianFFTImageFilterTest
-#   )
+ itk_add_test(NAME itkVkHalfHermitianFFTImageFilterTest
+   COMMAND VkFFTBackendTestDriver itkVkHalfHermitianFFTImageFilterTest
+   )


### PR DESCRIPTION
Re-enables CTests for quality control.

CTests complete locally on a device with an OpenCL platform available but fail in Github Actions due to OpenCL platform not available:

> Trying writer->Update()
 0/home/runner/work/ITKVkFFTBackend/ITKVkFFTBackend/src/itkVkCommon.cxx(69): clGetPlatformIDs returned -1001
 1
itk::ExceptionObject (0x55673784df80)
Location: "unknown" 
File: /home/runner/work/ITKVkFFTBackend/ITKVkFFTBackend/include/itkVkComplexToComplexFFTImageFilter.hxx
Line: 104
Description: ITK ERROR: VkFFT third-party library failed with error code 4042.

Github Actions [does not support GPU testing](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources). Can we support OpenCL CPU testing or would this require self-hosting runners?

@thewtex 