### PR TITLE
ENH: Move OpenCL link to VkFFTBackend library target definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,5 +64,3 @@ else()
   set(ITK_DIR ${CMAKE_BINARY_DIR})
   itk_module_impl()
 endif()
-
-target_link_libraries(VkFFTBackend PUBLIC ${OpenCL_LIBRARY})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,3 +3,4 @@ set(VkFFTBackend_SRCS
   )
 
 itk_module_add_library(VkFFTBackend ${VkFFTBackend_SRCS})
+target_link_libraries(VkFFTBackend PUBLIC ${OpenCL_LIBRARY})


### PR DESCRIPTION
Per discussion from #9 