### PR TITLE
ENH: Add GPU CI Testing with Cirun

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,0 +1,19 @@
+# Self-Hosted Github Action Runners on AWS via Cirun.io
+# Reference: https://docs.cirun.io/reference/yaml.html
+runners:
+  - name: gpu-runner
+    # Cloud Provider: Amazon Web Services
+    cloud: aws
+    # NVIDIA GPU
+    instance_type: g4dn.xlarge
+    # Custom-defined Ubuntu AMI with AMD drivers and build tools pre-installed
+    machine_image: ami-0328487742df7e739
+    region: us-east-2
+    preemptible: false
+    # Relevant workflow file
+    workflow: .github/workflows/test-gpu.yml
+    # Provision 1 runner for ubuntu testing for now
+    count: 1
+    # Add a label to match runs-on param in Github Actions yml files
+    labels:
+      - gpu

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,7 +3,7 @@ name: Build, test, package
 on: [push,pull_request]
 
 jobs:
-  build-test-cxx:
+  build-cxx:
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 3
@@ -202,15 +202,15 @@ jobs:
     - name: Build and test
       if: matrix.os != 'windows-2019'
       run: |
-        ctest --output-on-failure -j 2 -V -S dashboard.cmake
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "VkFFTBackend"
 
     - name: Build and test
       if: matrix.os == 'windows-2019'
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        ctest --output-on-failure -j 2 -V -S dashboard.cmake
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "VkFFTBackend"
       shell: cmd
-
+      
   build-windows-python-packages:
     runs-on: windows-2019
     strategy:

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -211,85 +211,7 @@ jobs:
         ctest --output-on-failure -j 2 -V -S dashboard.cmake
       shell: cmd
 
-  build-linux-python-packages:
-    needs:
-      - build-test-cxx
-    runs-on: ubuntu-20.04
-    strategy:
-      max-parallel: 2
-      matrix:
-        python-version: [36, 37, 38, 39]
-        include:
-          - itk-python-git-tag: "v5.2.0.post2"
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: 'Free up disk space'
-      run: |
-        # Workaround for https://github.com/actions/virtual-environments/issues/709
-        df -h
-        sudo apt-get clean
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        df -h
-
-    - name: 'Fetch build script'
-      run: |
-        curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
-        chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
-
-    - name: 'Build 🐍 Python 📦 package'
-      run: |
-        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
-        ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }}
-
-    - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: LinuxWheel${{ matrix.python-version }}
-        path: dist
-
-  build-macos-python-packages:
-    needs:
-      - build-test-cxx
-    runs-on: macos-10.15
-    strategy:
-      max-parallel: 2
-      matrix:
-        include:
-          - itk-python-git-tag: "v5.2.0.post2"
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: 'Specific XCode version'
-      run: |
-        sudo xcode-select -s "/Applications/Xcode_11.7.app"
-
-    - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.18.3
-
-    - name: 'Fetch build script'
-      run: |
-        curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
-        chmod u+x macpython-download-cache-and-build-module-wheels.sh
-
-    - name: 'Build 🐍 Python 📦 package'
-      run: |
-        export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
-        export MACOSX_DEPLOYMENT_TARGET=10.9
-        ./macpython-download-cache-and-build-module-wheels.sh
-
-    - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: MacOSWheels
-        path: dist
-
   build-windows-python-packages:
-    needs:
-      - build-test-cxx
     runs-on: windows-2019
     strategy:
       max-parallel: 2
@@ -297,6 +219,11 @@ jobs:
         python-version-minor: [6, 7, 8, 9]
         include:
           - itk-python-git-tag: "v5.2.0.post2"
+            c-compiler: "cl.exe"
+            cxx-compiler: "cl.exe"
+            opencl-icd-loader-git-tag: "v2021.04.29"
+            opencl-headers-git-tag: "v2021.04.29"
+            cmake-build-type: "MinSizeRel"
 
     steps:
     - name: Get specific version of CMake, Ninja
@@ -323,6 +250,32 @@ jobs:
         curl -L "https://data.kitware.com/api/v1/file/5bbf87ba8d777f06b91f27d6/download/grep-win.zip" -o "grep-win.zip"
         7z x grep-win.zip -o/c/P/grep -aoa -r
       shell: bash
+      
+    - name: Download OpenCL-ICD-Loader
+      run: |
+        cd ..
+        git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader
+        pushd OpenCL-ICD-Loader
+        git checkout ${{ matrix.opencl-icd-loader-git-tag }}
+        popd
+        pushd OpenCL-ICD-Loader/inc
+        git clone https://github.com/KhronosGroup/OpenCL-Headers
+        pushd OpenCL-Headers
+        git checkout ${{ matrix.opencl-headers-git-tag }}
+        popd
+        cp -r OpenCL-Headers/CL ./
+        popd
+      shell: bash
+
+    - name: Build OpenCL-ICD-Loader
+      run: |
+        cd ..
+        mkdir OpenCL-ICD-Loader-build
+        cd OpenCL-ICD-Loader-build
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../OpenCL-ICD-Loader
+        cmake --build . --target install
+      shell: cmd
 
     - name: 'Build 🐍 Python 📦 package'
       run: |
@@ -331,7 +284,7 @@ jobs:
         set PATH="C:\P\grep;%PATH%"
         set CC=cl.exe
         set CXX=cl.exe
-        C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64" --no-cleanup
+        C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64" --no-cleanup -- "-DOpenCL_INCLUDE_DIR:PATH=${{ github.workspace}}/../OpenCL-ICD-Loader/inc" "-DOpenCL_LIBRARY:FILEPATH=${{ github.workspace}}/../OpenCL-ICD-Loader-build/OpenCL.lib"
       shell: cmd
 
     - name: Publish Python package as GitHub Artifact
@@ -396,7 +349,6 @@ jobs:
       run: |
         export ITK_PACKAGE_VERSION=${{ matrix.itk-python-git-tag }}
         export MACOSX_DEPLOYMENT_TARGET=10.9
-        export ELASTIX_USE_OPENCL=1
         ./macpython-download-cache-and-build-module-wheels.sh
 
     - name: Publish Python package as GitHub Artifact
@@ -407,8 +359,8 @@ jobs:
 
   publish-python-packages-to-pypi:
     needs:
-      - build-linux-python-packages
-      - build-macos-python-packages
+      - build-linux-opencl-python-packages
+      - build-macos-opencl-python-packages
       - build-windows-python-packages
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -1,0 +1,131 @@
+name: Test GPU
+
+on: [pull_request]
+
+jobs:
+  build-test-gpu:
+    runs-on: [self-hosted, gpu]
+    strategy:
+      matrix:
+        include:
+          - opencl-icd-loader-git-tag: "v2021.04.29"
+            opencl-headers-git-tag: "v2021.04.29"
+            opencl-version: 120
+            vkfft-backend: 3
+            itk-git-tag: "c693dbc830859ea10d573301f075e121a4c6c581"
+            cmake-build-type: "MinSizeRel"
+            platform-name: "ubuntu-nvidia-gpu"
+            os: ubuntu-20.04
+        
+    steps:
+
+    - name: Check OpenCL Devices
+      run: |
+        clinfo
+        if [ $(clinfo | grep "Number of devices" | awk '{print $4}') == "0" ]; then echo "Could not find OpenCL devices" && exit 1; fi
+      shell: bash
+
+    - uses: actions/checkout@v2
+    
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+    
+    - name: Download OpenCL-ICD-Loader
+      run: |
+        cd ..
+        git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader
+        pushd OpenCL-ICD-Loader
+        git checkout ${{ matrix.opencl-icd-loader-git-tag }}
+        popd
+        pushd OpenCL-ICD-Loader/inc
+        git clone https://github.com/KhronosGroup/OpenCL-Headers
+        pushd OpenCL-Headers
+        git checkout ${{ matrix.opencl-headers-git-tag }}
+        popd
+        cp -r OpenCL-Headers/CL ./
+        popd
+      shell: bash
+      
+    - name: Download ITK
+      run: |
+        cd ..
+        git clone https://github.com/InsightSoftwareConsortium/ITK.git
+        cd ITK
+        git checkout ${{ matrix.itk-git-tag }}
+        
+    - name: Build OpenCL-ICD-Loader
+      run: |
+        cd ..
+        mkdir OpenCL-ICD-Loader-build
+        cd OpenCL-ICD-Loader-build
+        cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../OpenCL-ICD-Loader
+        cmake --build .
+
+    - name: Build ITK
+      run: |
+        cd ..
+        mkdir ITK-build
+        cd ITK-build
+        cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+        ninja
+    
+    - name: Fetch CTest driver script
+      run: |
+        curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+
+    - name: Configure CTest script
+      run: |
+        operating_system="${{ matrix.os }}"
+        platform_name="${{ matrix.platform-name }}"
+        cat > dashboard.cmake << EOF
+        set(CTEST_SITE "GitHubActions")
+        file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/.." CTEST_DASHBOARD_ROOT)
+        file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/" CTEST_SOURCE_DIRECTORY)
+        file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/../build" CTEST_BINARY_DIRECTORY)
+        set(dashboard_source_name "${GITHUB_REPOSITORY}")
+        if(ENV{GITHUB_REF} MATCHES "master")
+          set(branch "-master")
+          set(dashboard_model "Continuous")
+        else()
+          set(branch "-${GITHUB_REF}")
+          set(dashboard_model "Experimental")
+        endif()
+        set(CTEST_BUILD_NAME "${GITHUB_REPOSITORY}-${platform_name}-\${branch}")
+        set(CTEST_UPDATE_VERSION_ONLY 1)
+        set(CTEST_TEST_ARGS \${CTEST_TEST_ARGS} PARALLEL_LEVEL \${PARALLEL_LEVEL})
+        set(CTEST_BUILD_CONFIGURATION "Release")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(CTEST_CUSTOM_WARNING_EXCEPTION
+          \${CTEST_CUSTOM_WARNING_EXCEPTION}
+          # macOS Azure VM Warning
+          "ld: warning: text-based stub file"
+          )
+        set(dashboard_no_clean 1)
+        set(ENV{CC} ${{ matrix.c-compiler }})
+        set(ENV{CXX} ${{ matrix.cxx-compiler }})
+        if(WIN32)
+          set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
+        endif()
+        file(TO_CMAKE_PATH "\${CTEST_DASHBOARD_ROOT}/OpenCL-ICD-Loader/inc" OpenCL_INCLUDE_DIR)
+        find_library(OpenCL_LIBRARY OpenCL PATHS \${CTEST_DASHBOARD_ROOT}/OpenCL-ICD-Loader-build REQUIRED)
+        set(VKFFT_BACKEND ${{ matrix.vkfft-backend }} CACHE STRING "0 - Vulkan, 1 - CUDA, 2 - HIP, 3 - OpenCL")
+        set(dashboard_cache "
+        VKFFT_BACKEND=\${VKFFT_BACKEND}
+        CL_TARGET_OPENCL_VERSION=${{ matrix.opencl-version }}
+        OpenCL_INCLUDE_DIR:PATH=\${OpenCL_INCLUDE_DIR}
+        OpenCL_LIBRARY:FILEPATH=\${OpenCL_LIBRARY}
+        ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
+        BUILD_TESTING:BOOL=ON
+        ")
+        string(TIMESTAMP build_date "%Y-%m-%d")
+        message("CDash Build Identifier: \${build_date} \${CTEST_BUILD_NAME}")
+        message("CTEST_SITE = \${CTEST_SITE}")
+        message("dashboard_cache = \${dashboard_cache}")
+        include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+        EOF
+        cat dashboard.cmake
+      shell: bash
+
+    - name: Build and test
+      run: |
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,19 +13,19 @@ CreateTestDriver(VkFFTBackend
   "${VkFFTBackendTests}"
   )
 
-# itk_add_test(NAME itkVkComplexToComplexFFTImageFilterTest
-#   COMMAND VkFFTBackendTestDriver
-#     --compare
-#     DATA{Baseline/itkVkComplexToComplexFFTImageFilterTestOutput.mha}
-#     ${ITK_TEST_OUTPUT_DIR}/itkVkComplexToComplexFFTImageFilterTestOutput.mha
-#   itkVkComplexToComplexFFTImageFilterTest
-#     ${ITK_TEST_OUTPUT_DIR}/itkVkComplexToComplexFFTImageFilterTestOutput.mha
-#   )
+ itk_add_test(NAME itkVkComplexToComplexFFTImageFilterTest
+   COMMAND VkFFTBackendTestDriver
+     --compare
+     DATA{Baseline/itkVkComplexToComplexFFTImageFilterTestOutput.mha}
+     ${ITK_TEST_OUTPUT_DIR}/itkVkComplexToComplexFFTImageFilterTestOutput.mha
+   itkVkComplexToComplexFFTImageFilterTest
+     ${ITK_TEST_OUTPUT_DIR}/itkVkComplexToComplexFFTImageFilterTestOutput.mha
+   )
 
-# itk_add_test(NAME itkVkForwardInverseFFTImageFilterTest
-#   COMMAND VkFFTBackendTestDriver itkVkForwardInverseFFTImageFilterTest
-#   )
+ itk_add_test(NAME itkVkForwardInverseFFTImageFilterTest
+   COMMAND VkFFTBackendTestDriver itkVkForwardInverseFFTImageFilterTest
+   )
 
-# itk_add_test(NAME itkVkHalfHermitianFFTImageFilterTest
-#   COMMAND VkFFTBackendTestDriver itkVkHalfHermitianFFTImageFilterTest
-#   )
+ itk_add_test(NAME itkVkHalfHermitianFFTImageFilterTest
+   COMMAND VkFFTBackendTestDriver itkVkHalfHermitianFFTImageFilterTest
+   )

--- a/wrapping/dockcross-manylinux-build-module-wheels-opencl.sh
+++ b/wrapping/dockcross-manylinux-build-module-wheels-opencl.sh
@@ -35,7 +35,7 @@ fi
 
 # Build wheels
 mkdir -p dist
-DOCKER_ARGS="-e ELASTIX_USE_OPENCL=1 -v $(pwd)/dist:/work/dist/ -v $script_dir/../ITKPythonPackage:/ITKPythonPackage -v $(pwd)/tools:/tools -v $(pwd)/OpenCL-ICD-Loader/inc/CL:/usr/include/CL -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so.1 -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so"
+DOCKER_ARGS="-v $(pwd)/dist:/work/dist/ -v $script_dir/../ITKPythonPackage:/ITKPythonPackage -v $(pwd)/tools:/tools -v $(pwd)/OpenCL-ICD-Loader/inc/CL:/usr/include/CL -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so.1 -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so"
 /tmp/dockcross-manylinux-x64 \
   -a "$DOCKER_ARGS" \
   "/ITKPythonPackage/scripts/internal/manylinux-build-module-wheels.sh" "$@"


### PR DESCRIPTION
Add support for accelerated testing with AWS EC2 NVIDIA GPU node + [Cirun.io](https://cirun.io/).

This splits CI into two parts:
- Cross-platform build support is checked on the default Github Actions CI runners with CPU-only support. CTests are limited to module-level tests for KWStyle and Doxygen.
- GPU acceleration functionality is checked with NVIDIA drivers on an AWS `g4dn.xlarge` instance spun up at the time of CI execution. This executes all CTests included in the project on a GPU.

At the moment building+testing on AWS GPU takes 10 minutes, so we can estimate a cost of $0.5260 / 60 min * 10 min = $0.088 per CI execution. We can investigate the reliability of spot instances to further drop the cost.

Future work will add additional GPU runners for cross-platform acceleration testing. GPU results can be viewed on [CDash](https://open.cdash.org/index.php?project=Insight).