### PR TITLE
BUG: Get complex types for conditional wrapping

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -284,7 +284,7 @@ jobs:
         set PATH="C:\P\grep;%PATH%"
         set CC=cl.exe
         set CXX=cl.exe
-        C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64" --no-cleanup -- "-DOpenCL_INCLUDE_DIR:PATH=${{ github.workspace}}/../OpenCL-ICD-Loader/inc" "-DOpenCL_LIBRARY:FILEPATH=${{ github.workspace}}/../OpenCL-ICD-Loader-build/OpenCL.lib"
+        C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64" --no-cleanup --lib-paths="${{ github.workspace}}/../OpenCL-ICD-Loader-build" -- "-DOpenCL_INCLUDE_DIR:PATH=${{ github.workspace}}/../OpenCL-ICD-Loader/inc" "-DOpenCL_LIBRARY:FILEPATH=${{ github.workspace}}/../OpenCL-ICD-Loader-build/OpenCL.lib"
       shell: cmd
 
     - name: Publish Python package as GitHub Artifact

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -12,7 +12,7 @@ jobs:
             opencl-headers-git-tag: "v2021.04.29"
             opencl-version: 120
             vkfft-backend: 3
-            itk-git-tag: "b1a0a91614dc091f9a17c1e4727095c80e9c05ea"
+            itk-git-tag: "ddef776afb46a6e135ba3c9f58a0e6e7e4a000be"
             cmake-build-type: "MinSizeRel"
             platform-name: "ubuntu-nvidia-gpu"
             os: ubuntu-20.04

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,3 +1,13 @@
+set(ITK_WRAP_COMPLEX_FLOAT OFF)
+if("CF" IN_LIST WRAP_ITK_COMPLEX_REAL)
+  set(ITK_WRAP_COMPLEX_FLOAT ON)
+endif()
+
+set(ITK_WRAP_COMPLEX_DOUBLE OFF)
+if("CD" IN_LIST WRAP_ITK_COMPLEX_REAL)
+  set(ITK_WRAP_COMPLEX_DOUBLE ON)
+endif()
+
 itk_wrap_module("VkFFTBackend")
 itk_auto_load_submodules()
 itk_end_wrap_module()


### PR DESCRIPTION
Workaround for propagating ITK complex types enabled for wrapping.

`ITK_WRAP_COMPLEX_FLOAT` and `ITK_WRAP_COMPLEX_DOUBLE` are CMake variables in ITK but which are not propagated to external modules. This change reconstructs the variables by querying the `ITK_WRAP_COMPLEX_REAL` list which is built from the individual complex type flags and propagated from ITK.