### PR TITLE
ENH: Add default factory initialization

### DIFF
--- a/include/itkVkComplexToComplexFFTImageFilter.h
+++ b/include/itkVkComplexToComplexFFTImageFilter.h
@@ -127,6 +127,7 @@ struct FFTImageFilterTraits<VkComplexToComplexFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/include/itkVkFFTImageFilterInitFactory.h
+++ b/include/itkVkFFTImageFilterInitFactory.h
@@ -1,0 +1,74 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkVkFFTImageFilterInitFactory_h
+#define itkVkFFTImageFilterInitFactory_h
+#include "VkFFTBackendExport.h"
+
+#include "itkLightObject.h"
+
+namespace itk
+{
+/**
+ *\class VkFFTImageFilterInitFactory
+ * \brief Initialize Vk FFT image filter factory backends.
+ *
+ * The purpose of VkFFTImageFilterInitFactory is to perform
+ * one-time registration of factory objects that handle
+ * creation of Vk-backend FFT image filter classes
+ * through the ITK object factory singleton mechanism.
+ *
+ * \ingroup FourierTransform
+ * \ingroup ITKFFT
+ * \ingroup ITKSystemObjects
+ * \ingroup VkFFTBackend
+ */
+class VkFFTBackend_EXPORT VkFFTImageFilterInitFactory : public LightObject
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(VkFFTImageFilterInitFactory);
+
+  /** Standard class type aliases. */
+  using Self = VkFFTImageFilterInitFactory;
+  using Superclass = LightObject;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Method for class instantiation. */
+  itkFactorylessNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(VkFFTImageFilterInitFactory, LightObject);
+
+  /** Mimic factory interface for Python initialization  */
+  static void
+  RegisterOneFactory()
+  {
+    RegisterFactories();
+  }
+
+  /** Register all Vk FFT factories */
+  static void
+  RegisterFactories();
+
+protected:
+  VkFFTImageFilterInitFactory();
+  ~VkFFTImageFilterInitFactory() override = default;
+};
+} // end namespace itk
+
+#endif

--- a/include/itkVkForward1DFFTImageFilter.h
+++ b/include/itkVkForward1DFFTImageFilter.h
@@ -134,6 +134,7 @@ struct FFTImageFilterTraits<VkForward1DFFTImageFilter>
   using InputPixelType = TUnderlying;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/include/itkVkForwardFFTImageFilter.h
+++ b/include/itkVkForwardFFTImageFilter.h
@@ -132,6 +132,7 @@ struct FFTImageFilterTraits<VkForwardFFTImageFilter>
   using InputPixelType = TUnderlying;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
@@ -133,6 +133,7 @@ struct FFTImageFilterTraits<VkHalfHermitianToRealInverseFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = TUnderlying;
+  using FilterDimensions = std::integer_sequence<unsigned int, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/include/itkVkInverse1DFFTImageFilter.h
+++ b/include/itkVkInverse1DFFTImageFilter.h
@@ -135,6 +135,7 @@ struct FFTImageFilterTraits<VkInverse1DFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = TUnderlying;
+  using FilterDimensions = std::integer_sequence<unsigned int, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/include/itkVkInverseFFTImageFilter.h
+++ b/include/itkVkInverseFFTImageFilter.h
@@ -132,6 +132,7 @@ struct FFTImageFilterTraits<VkInverseFFTImageFilter>
   using InputPixelType = std::complex<TUnderlying>;
   template <typename TUnderlying>
   using OutputPixelType = TUnderlying;
+  using FilterDimensions = std::integer_sequence<unsigned int, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
+++ b/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
@@ -133,6 +133,7 @@ struct FFTImageFilterTraits<VkRealToHalfHermitianForwardFFTImageFilter>
   using InputPixelType = TUnderlying;
   template <typename TUnderlying>
   using OutputPixelType = std::complex<TUnderlying>;
+  using FilterDimensions = std::integer_sequence<unsigned int, 3, 2, 1>;
 };
 
 } // namespace itk

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -25,6 +25,8 @@ itk_module(VkFFTBackend
     ITKImageIntensity
   DESCRIPTION
     "${DOCUMENTATION}"
+  FACTORY_NAMES
+    "FFTImageFilterInit::Vk"
   EXCLUDE_FROM_DEFAULT
   ENABLE_SHARED
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(VkFFTBackend_SRCS
   itkVkCommon.cxx
   itkVkGlobalConfiguration.cxx
+  itkVkFFTImageFilterInitFactory.cxx
   )
 
 itk_module_add_library(VkFFTBackend ${VkFFTBackend_SRCS})

--- a/src/itkVkFFTImageFilterInitFactory.cxx
+++ b/src/itkVkFFTImageFilterInitFactory.cxx
@@ -1,0 +1,67 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "ITKFFTExport.h"
+
+#include "itkVkComplexToComplex1DFFTImageFilter.h"
+#include "itkVkComplexToComplexFFTImageFilter.h"
+#include "itkFFTImageFilterFactory.h"
+#include "itkVkForward1DFFTImageFilter.h"
+#include "itkVkForwardFFTImageFilter.h"
+#include "itkVkHalfHermitianToRealInverseFFTImageFilter.h"
+#include "itkVkInverse1DFFTImageFilter.h"
+#include "itkVkInverseFFTImageFilter.h"
+#include "itkVkRealToHalfHermitianForwardFFTImageFilter.h"
+
+#include "itkVkFFTImageFilterInitFactory.h"
+
+namespace itk
+{
+VkFFTImageFilterInitFactory::VkFFTImageFilterInitFactory()
+{
+  VkFFTImageFilterInitFactory::RegisterFactories();
+}
+
+void VkFFTImageFilterInitFactory::RegisterFactories()
+{
+  itk::ObjectFactoryBase::RegisterFactory(FFTImageFilterFactory<VkComplexToComplex1DFFTImageFilter>::New(),
+                                          itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
+  itk::ObjectFactoryBase::RegisterFactory(FFTImageFilterFactory<VkComplexToComplexFFTImageFilter>::New(),
+                                          itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
+  itk::ObjectFactoryBase::RegisterFactory(FFTImageFilterFactory<VkForward1DFFTImageFilter>::New(),
+                                          itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
+  itk::ObjectFactoryBase::RegisterFactory(FFTImageFilterFactory<VkForwardFFTImageFilter>::New(),
+                                          itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
+  itk::ObjectFactoryBase::RegisterFactory(FFTImageFilterFactory<VkHalfHermitianToRealInverseFFTImageFilter>::New(),
+                                          itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
+  itk::ObjectFactoryBase::RegisterFactory(FFTImageFilterFactory<VkInverse1DFFTImageFilter>::New(),
+                                          itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
+  itk::ObjectFactoryBase::RegisterFactory(FFTImageFilterFactory<VkInverseFFTImageFilter>::New(),
+                                          itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
+  itk::ObjectFactoryBase::RegisterFactory(FFTImageFilterFactory<VkRealToHalfHermitianForwardFFTImageFilter>::New(),
+                                          itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
+}
+
+// Undocumented API used to register during static initialization.
+// DO NOT CALL DIRECTLY.
+void VkFFTBackend_EXPORT
+VkFFTImageFilterInitFactoryRegister__Private()
+{
+  VkFFTImageFilterInitFactory::RegisterFactories();
+}
+
+} // end namespace itk

--- a/test/itkVkFFTImageFilterFactoryTest.cxx
+++ b/test/itkVkFFTImageFilterFactoryTest.cxx
@@ -22,6 +22,7 @@
 #include "itkComplexToComplex1DFFTImageFilter.h"
 #include "itkVkComplexToComplex1DFFTImageFilter.h"
 #include "itkVnlComplexToComplex1DFFTImageFilter.h"
+#include "itkVkFFTImageFilterInitFactory.h"
 
 #include "itkFFTImageFilterFactory.h"
 #include "itkTestingMacros.h"
@@ -62,6 +63,16 @@ itkVkFFTImageFilterFactoryTest(int, char *[])
   vnlFFT = dynamic_cast<FFTDefaultSubclassType *>(fft.GetPointer());
   ITK_TEST_EXPECT_TRUE(vnlFFT != nullptr);
   ITK_EXERCISE_BASIC_OBJECT_METHODS(vnlFFT, VnlComplexToComplex1DFFTImageFilter, ComplexToComplex1DFFTImageFilter);
+
+  // Verify factory initialization successfully registers factories
+  using FactoryInitializerType = itk::VkFFTImageFilterInitFactory;
+  FactoryInitializerType::RegisterFactories();
+
+  fft = FFTBaseType::New();
+  vkFFT = dynamic_cast<FFTVkSubclassType *>(fft.GetPointer());
+  ITK_TEST_EXPECT_TRUE(vkFFT != nullptr);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vkFFT, VkComplexToComplex1DFFTImageFilter, ComplexToComplex1DFFTImageFilter);
+
 
   return EXIT_SUCCESS;
 }

--- a/wrapping/itkVkFFTImageFilterInitFactory.wrap
+++ b/wrapping/itkVkFFTImageFilterInitFactory.wrap
@@ -1,0 +1,1 @@
+itk_wrap_simple_class("itk::VkFFTImageFilterInitFactory" POINTER)


### PR DESCRIPTION
Leverages the `InitFactory` mechanism introduced in ITK commit c266651
to register VkFFT GPU-accelerated implementation classes as the default
backends for ITK FFT classes via the object factory.

With these changes in place, GPU acceleration of ITK FFT image filters is achieved by simply installing the `itk-vkfftbackend` Python module:
```py
> pip install itk itk-vkfftbackend
> python
>>> import itk
>>> fft_filter = itk.ForwardFFTImageFilter.values()[-1].New()        # base FFT filter instantiated
>>> t1 = itk.VkForwardFFTImageFilter.values()[-1]                  # Prove instance is VkFFT backend with a cast
>>> t1.cast(fft_filter)
<itk.itkVkForwardFFTImageFilterPython.itkVkForwardFFTImageFilterIF3; proxy of <Swig Object of type 'itkVkForwardFFTImageFilterIF3 *' at 0x0000016275980270> >
```

This PR relies on ITK features that will be available in the ITK 5.3rc04 prerelease, may need to wait for that release in order for CI to pass. I have verified tests pass on my local Windows system when built against the ITK main branch.