### PR TITLE
BUG: Match `VkHalfHermitianInverseFFTImageFilter`'s base class interface

### DIFF
--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
@@ -85,11 +85,9 @@ public:
 
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
+  /** Platform identifier for accelerator backend */
   itkGetMacro(DeviceID, uint64_t);
   itkSetMacro(DeviceID, uint64_t);
-
-  itkSetMacro(OutputRegion, OutputImageRegionType);
-  itkGetConstMacro(OutputRegion, OutputImageRegionType);
 
   SizeValueType
   GetSizeGreatestPrimeFactor() const override;
@@ -106,8 +104,6 @@ protected:
 
 private:
   uint64_t m_DeviceID{ 0UL };
-
-  OutputImageRegionType m_OutputRegion;
 
   VkCommon m_VkCommon{};
 };

--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -52,7 +52,7 @@ VkHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::GenerateD
   const ProgressReporter progress(this, 0, 1);
 
   // allocate output buffer memory
-  output->SetRegions(this->GetOutputRegion());
+  output->SetRegions(output->GetRequestedRegion());
   output->Allocate();
 
   const SizeType & outputSize{ output->GetBufferedRegion().GetSize() };

--- a/test/itkVkHalfHermitianFFTImageFilterTest.cxx
+++ b/test/itkVkHalfHermitianFFTImageFilterTest.cxx
@@ -86,6 +86,7 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
 
       size.Fill(0);
       size[0] = mySize;
+      bool xIsOdd = (mySize % 2 == 1);
 
       typename RealImageType::Pointer realImage{ RealImageType::New() };
       realImage->SetRegions(size);
@@ -149,8 +150,7 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
 
       thisTestPassed = true;
       inverseFilter->SetInput(output);
-      index[0] = 0;
-      inverseFilter->SetOutputRegion({ index, size });
+      inverseFilter->SetActualXDimensionIsOdd(xIsOdd);
       inverseFilter->Update();
       typename RealImageType::Pointer        output2{ inverseFilter->GetOutput() };
       const typename RealImageType::SizeType output2Size{ output2->GetLargestPossibleRegion().GetSize() };


### PR DESCRIPTION
Modifies Vk implementation interface to match base class:
- Output region is set by base class rather than input parameter
- Set even/odd output dimension flag via input parameter

Resolves #27 where FFT factory override failed due to different
interface expectations.