### PR TITLE
ENH: Expose global parameter for GPU platform setting

### DIFF
--- a/include/itkVkComplexToComplex1DFFTImageFilter.h
+++ b/include/itkVkComplexToComplex1DFFTImageFilter.h
@@ -19,9 +19,10 @@
 #ifndef itkVkComplexToComplex1DFFTImageFilter_h
 #define itkVkComplexToComplex1DFFTImageFilter_h
 
+#include "itkComplexToComplex1DFFTImageFilter.h"
 #include "itkFFTImageFilterFactory.h"
 #include "itkVkCommon.h"
-#include "itkComplexToComplex1DFFTImageFilter.h"
+#include "itkVkGlobalConfiguration.h"
 
 namespace itk
 {
@@ -34,9 +35,9 @@ namespace itk
  *  the VkFFT library.
  *
  * This filter is multithreaded and by default supports input images with sizes which are
- * divisible by primes up to 13. 
- * 
- * Execution on input images with sizes divisible by primes greater than 17 may succeed 
+ * divisible only by primes up to 13.
+ *
+ * Execution on input images with sizes divisible by primes greater than 13 may succeed
  * with a fallback on Bluestein's algorithm per VkFFT with a cost to performance and output precision.
  *
  * \ingroup FourierTransform
@@ -81,8 +82,24 @@ public:
 
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
-  itkGetMacro(DeviceID, uint64_t);
+  /** Determine whether local or global properties will be
+   *  referenced for setting up GPU acceleration.
+   *  Defaults to global so that the user can adjust default properties
+   *  in filters constructed through the ITK object factory. */
+  itkSetMacro(UseVkGlobalConfiguration, bool);
+  itkGetMacro(UseVkGlobalConfiguration, bool);
+
+  /** Local setting for enumerated GPU device to use for FFT.
+   *  Ignored if `UseVkGlobalConfiguration` is true. */
   itkSetMacro(DeviceID, uint64_t);
+
+  /** Return the enumerated GPU device to use for FFT
+   *  according to current filter settings. */
+  uint64_t
+  GetDeviceID() const
+  {
+    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+  }
 
   SizeValueType
   GetSizeGreatestPrimeFactor() const override;
@@ -98,8 +115,8 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
+  bool     m_UseVkGlobalConfiguration{true};
   uint64_t m_DeviceID{ 0UL };
-
   VkCommon m_VkCommon{};
 };
 

--- a/include/itkVkComplexToComplex1DFFTImageFilter.hxx
+++ b/include/itkVkComplexToComplex1DFFTImageFilter.hxx
@@ -20,6 +20,7 @@
 #define itkVkComplexToComplex1DFFTImageFilter_hxx
 
 #include "itkVkComplexToComplex1DFFTImageFilter.h"
+#include "itkVkGlobalConfiguration.h"
 #include "vkFFT.h"
 #include "itkImageRegionIterator.h"
 #include "itkIndent.h"
@@ -61,7 +62,7 @@ VkComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Mostly use defaults for VkCommon::VkGPU
   typename VkCommon::VkGPU vkGPU;
-  vkGPU.device_id = m_DeviceID;
+  vkGPU.device_id = this->GetDeviceID();
 
   // Describe this filter in VkCommon::VkParameters
   typename VkCommon::VkParameters vkParameters;
@@ -112,7 +113,10 @@ void
 VkComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "UseVkGlobalConfiguration: " << m_UseVkGlobalConfiguration << std::endl;
+  os << indent << "Local DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "Global DeviceID: " << VkGlobalConfiguration::GetDeviceID() << std::endl;
+  os << indent << "Preferred DeviceID: " << this->GetDeviceID() << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/include/itkVkComplexToComplexFFTImageFilter.h
+++ b/include/itkVkComplexToComplexFFTImageFilter.h
@@ -19,9 +19,10 @@
 #ifndef itkVkComplexToComplexFFTImageFilter_h
 #define itkVkComplexToComplexFFTImageFilter_h
 
+#include "itkComplexToComplexFFTImageFilter.h"
 #include "itkFFTImageFilterFactory.h"
 #include "itkVkCommon.h"
-#include "itkComplexToComplexFFTImageFilter.h"
+#include "itkVkGlobalConfiguration.h"
 
 namespace itk
 {
@@ -34,7 +35,7 @@ namespace itk
  *  the VkFFT library.
  *
  * This filter is multithreaded and supports input images with sizes which are
- * divisible by primes up to 13.
+ * divisible only by primes up to 13.
  *
  * \ingroup FourierTransform
  * \ingroup MultiThreaded
@@ -78,8 +79,24 @@ public:
 
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
-  itkGetMacro(DeviceID, uint64_t);
+  /** Determine whether local or global properties will be
+   *  referenced for setting up GPU acceleration.
+   *  Defaults to global so that the user can adjust default properties
+   *  in filters constructed through the ITK object factory. */
+  itkSetMacro(UseVkGlobalConfiguration, bool);
+  itkGetMacro(UseVkGlobalConfiguration, bool);
+
+  /** Local setting for enumerated GPU device to use for FFT.
+   *  Ignored if `UseVkGlobalConfiguration` is true. */
   itkSetMacro(DeviceID, uint64_t);
+
+  /** Return the enumerated GPU device to use for FFT
+   *  according to current filter settings. */
+  uint64_t
+  GetDeviceID() const
+  {
+    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+  }
 
   SizeValueType
   GetSizeGreatestPrimeFactor() const;
@@ -95,6 +112,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
+  bool     m_UseVkGlobalConfiguration{true};
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkComplexToComplexFFTImageFilter.hxx
+++ b/include/itkVkComplexToComplexFFTImageFilter.hxx
@@ -66,7 +66,7 @@ VkComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Mostly use defaults for VkCommon::VkGPU
   typename VkCommon::VkGPU vkGPU;
-  vkGPU.device_id = m_DeviceID;
+  vkGPU.device_id = this->GetDeviceID();
 
   // Describe this filter in VkCommon::VkParameters
   typename VkCommon::VkParameters vkParameters;
@@ -110,7 +110,10 @@ void
 VkComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "UseVkGlobalConfiguration: " << m_UseVkGlobalConfiguration << std::endl;
+  os << indent << "Local DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "Global DeviceID: " << VkGlobalConfiguration::GetDeviceID() << std::endl;
+  os << indent << "Preferred DeviceID: " << this->GetDeviceID() << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/include/itkVkForward1DFFTImageFilter.hxx
+++ b/include/itkVkForward1DFFTImageFilter.hxx
@@ -61,7 +61,7 @@ VkForward1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Mostly use defaults for VkCommon::VkGPU
   typename VkCommon::VkGPU vkGPU;
-  vkGPU.device_id = m_DeviceID;
+  vkGPU.device_id = this->GetDeviceID();
 
   // Describe this filter in VkCommon::VkParameters
   typename VkCommon::VkParameters vkParameters;
@@ -108,7 +108,10 @@ void
 VkForward1DFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "UseVkGlobalConfiguration: " << m_UseVkGlobalConfiguration << std::endl;
+  os << indent << "Local DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "Global DeviceID: " << VkGlobalConfiguration::GetDeviceID() << std::endl;
+  os << indent << "Preferred DeviceID: " << this->GetDeviceID() << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/include/itkVkForwardFFTImageFilter.h
+++ b/include/itkVkForwardFFTImageFilter.h
@@ -22,6 +22,7 @@
 #include "itkForwardFFTImageFilter.h"
 #include "itkImage.h"
 #include "itkVkCommon.h"
+#include "itkVkGlobalConfiguration.h"
 
 namespace itk
 {
@@ -34,7 +35,7 @@ namespace itk
  * implementation is based on the VkFFT library.
  *
  * This filter is multithreaded and supports input images with sizes which are
- * divisible by primes up to 13.
+ * divisible only by primes up to 13.
  *
  * \ingroup FourierTransform
  * \ingroup MultiThreaded
@@ -83,8 +84,24 @@ public:
 
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
-  itkGetMacro(DeviceID, uint64_t);
+  /** Determine whether local or global properties will be
+   *  referenced for setting up GPU acceleration.
+   *  Defaults to global so that the user can adjust default properties
+   *  in filters constructed through the ITK object factory. */
+  itkSetMacro(UseVkGlobalConfiguration, bool);
+  itkGetMacro(UseVkGlobalConfiguration, bool);
+
+  /** Local setting for enumerated GPU device to use for FFT.
+   *  Ignored if `UseVkGlobalConfiguration` is true. */
   itkSetMacro(DeviceID, uint64_t);
+
+  /** Return the enumerated GPU device to use for FFT
+   *  according to current filter settings. */
+  uint64_t
+  GetDeviceID() const
+  {
+    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+  }
 
   SizeValueType
   GetSizeGreatestPrimeFactor() const override;
@@ -100,6 +117,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
+  bool     m_UseVkGlobalConfiguration{true};
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkForwardFFTImageFilter.hxx
+++ b/include/itkVkForwardFFTImageFilter.hxx
@@ -66,7 +66,7 @@ VkForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Mostly use defaults for VkCommon::VkGPU
   typename VkCommon::VkGPU vkGPU;
-  vkGPU.device_id = m_DeviceID;
+  vkGPU.device_id = this->GetDeviceID();
 
   // Describe this filter in VkCommon::VkParameters
   typename VkCommon::VkParameters vkParameters;
@@ -106,7 +106,10 @@ void
 VkForwardFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "UseVkGlobalConfiguration: " << m_UseVkGlobalConfiguration << std::endl;
+  os << indent << "Local DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "Global DeviceID: " << VkGlobalConfiguration::GetDeviceID() << std::endl;
+  os << indent << "Preferred DeviceID: " << this->GetDeviceID() << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/include/itkVkGlobalConfiguration.h
+++ b/include/itkVkGlobalConfiguration.h
@@ -1,0 +1,86 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkVkGlobalConfiguration_h
+#define itkVkGlobalConfiguration_h
+
+#include "VkFFTBackendExport.h"
+#include "itkLightObject.h"
+#include "itkMacro.h"
+
+namespace itk
+{
+
+/**
+ * \class VkGlobalConfigurationGlobals
+ *  \brief Implementation detail to reference the VkGlobalConfiguration singleton
+ *  \ingroup VkFFTBackend
+ */
+struct VkGlobalConfigurationGlobals;
+
+/**
+ *\class VkGlobalConfiguration
+ *
+ *  \brief Implements a singleton instance for setting global VkFFT default parameters.
+ *
+ * \ingroup VkFFTBackend
+ */
+class VkFFTBackend_EXPORT VkGlobalConfiguration : public LightObject
+{
+public:
+  ITK_DISALLOW_COPY_AND_MOVE(VkGlobalConfiguration);
+
+  /** Standard class type aliases. */
+  using Self = VkGlobalConfiguration;
+  using Superclass = LightObject;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(VkGlobalConfiguration, LightObject);
+
+  /** Default accelerated platform identifier */
+  static void
+  SetDeviceID(const uint64_t id);
+
+  /** Default accelerated platform identifier */
+  static uint64_t
+  GetDeviceID();
+
+private:
+  VkGlobalConfiguration() = default;
+  ~VkGlobalConfiguration() override = default;
+
+  /** Access synchronized global singleton */
+  static Pointer
+  GetInstance();
+
+  itkGetGlobalDeclarationMacro(VkGlobalConfigurationGlobals, PimplGlobals);
+
+  /** This is a singleton pattern New.  There will only be ONE
+   * reference to a VkGlobalConfiguration object per process.
+   * The single instance will be unreferenced when
+   * the program exits. */
+  itkFactorylessNewMacro(Self);
+
+  static VkGlobalConfigurationGlobals * m_PimplGlobals;
+
+  uint64_t m_DeviceID{ 0 };
+};
+} // namespace itk
+
+#endif // itkVkGlobalConfiguration_h

--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
@@ -22,6 +22,7 @@
 #include "itkHalfHermitianToRealInverseFFTImageFilter.h"
 #include "itkImage.h"
 #include "itkVkCommon.h"
+#include "itkVkGlobalConfiguration.h"
 
 namespace itk
 {
@@ -34,7 +35,7 @@ namespace itk
  * implementation is based on the VkFFT library.
  *
  * This filter is multithreaded and supports input images with sizes which are
- * divisible by primes up to 13.
+ * divisible only by primes up to 13.
  *
  * \ingroup FourierTransform
  * \ingroup MultiThreaded
@@ -47,8 +48,7 @@ namespace itk
 template <typename TInputImage,
           typename TOutputImage = Image<typename TInputImage::PixelType::value_type, TInputImage::ImageDimension>>
 class VkHalfHermitianToRealInverseFFTImageFilter
-  : public HalfHermitianToRealInverseFFTImageFilter<
-      TInputImage, TOutputImage>
+  : public HalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(VkHalfHermitianToRealInverseFFTImageFilter);
@@ -85,9 +85,24 @@ public:
 
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
-  /** Platform identifier for accelerator backend */
-  itkGetMacro(DeviceID, uint64_t);
+  /** Determine whether local or global properties will be
+   *  referenced for setting up GPU acceleration.
+   *  Defaults to global so that the user can adjust default properties
+   *  in filters constructed through the ITK object factory. */
+  itkSetMacro(UseVkGlobalConfiguration, bool);
+  itkGetMacro(UseVkGlobalConfiguration, bool);
+
+  /** Local platform identifier for accelerated backend.
+   *  Ignored if `UseVkGlobalConfiguration` is true. */
   itkSetMacro(DeviceID, uint64_t);
+
+  /** Return the enumerated GPU device to use for FFT
+   *  according to current filter settings. */
+  uint64_t
+  GetDeviceID() const
+  {
+    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+  }
 
   SizeValueType
   GetSizeGreatestPrimeFactor() const override;
@@ -103,6 +118,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
+  bool     m_UseVkGlobalConfiguration{true};
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -69,7 +69,7 @@ VkHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::GenerateD
 
   // Mostly use defaults for VkCommon::VkGPU
   typename VkCommon::VkGPU vkGPU;
-  vkGPU.device_id = m_DeviceID;
+  vkGPU.device_id = this->GetDeviceID();
 
   // Describe this filter in VkCommon::VkParameters
   typename VkCommon::VkParameters vkParameters;
@@ -109,7 +109,10 @@ void
 VkHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "UseVkGlobalConfiguration: " << m_UseVkGlobalConfiguration << std::endl;
+  os << indent << "Local DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "Global DeviceID: " << VkGlobalConfiguration::GetDeviceID() << std::endl;
+  os << indent << "Preferred DeviceID: " << this->GetDeviceID() << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/include/itkVkInverse1DFFTImageFilter.hxx
+++ b/include/itkVkInverse1DFFTImageFilter.hxx
@@ -61,7 +61,7 @@ VkInverse1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Mostly use defaults for VkCommon::VkGPU
   typename VkCommon::VkGPU vkGPU;
-  vkGPU.device_id = m_DeviceID;
+  vkGPU.device_id = this->GetDeviceID();
 
   // Describe this filter in VkCommon::VkParameters
   typename VkCommon::VkParameters vkParameters;
@@ -108,7 +108,10 @@ void
 VkInverse1DFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "UseVkGlobalConfiguration: " << m_UseVkGlobalConfiguration << std::endl;
+  os << indent << "Local DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "Global DeviceID: " << VkGlobalConfiguration::GetDeviceID() << std::endl;
+  os << indent << "Preferred DeviceID: " << this->GetDeviceID() << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/include/itkVkInverseFFTImageFilter.hxx
+++ b/include/itkVkInverseFFTImageFilter.hxx
@@ -31,12 +31,12 @@ namespace itk
 {
 
 template <typename TInputImage, typename TOutputImage>
-VkInverseFFTImageFilter<TInputImage,TOutputImage>::VkInverseFFTImageFilter()
+VkInverseFFTImageFilter<TInputImage, TOutputImage>::VkInverseFFTImageFilter()
 {}
 
 template <typename TInputImage, typename TOutputImage>
 void
-VkInverseFFTImageFilter<TInputImage,TOutputImage>::GenerateData()
+VkInverseFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
   // get pointers to the input and output
   const InputImageType * const input{ this->GetInput() };
@@ -66,7 +66,7 @@ VkInverseFFTImageFilter<TInputImage,TOutputImage>::GenerateData()
 
   // Mostly use defaults for VkCommon::VkGPU
   typename VkCommon::VkGPU vkGPU;
-  vkGPU.device_id = m_DeviceID;
+  vkGPU.device_id = this->GetDeviceID();
 
   // Describe this filter in VkCommon::VkParameters
   typename VkCommon::VkParameters vkParameters;
@@ -103,15 +103,18 @@ VkInverseFFTImageFilter<TInputImage,TOutputImage>::GenerateData()
 
 template <typename TInputImage, typename TOutputImage>
 void
-VkInverseFFTImageFilter<TInputImage,TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
+VkInverseFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "UseVkGlobalConfiguration: " << m_UseVkGlobalConfiguration << std::endl;
+  os << indent << "Local DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "Global DeviceID: " << VkGlobalConfiguration::GetDeviceID() << std::endl;
+  os << indent << "Preferred DeviceID: " << this->GetDeviceID() << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>
-typename VkInverseFFTImageFilter<TInputImage,TOutputImage>::SizeValueType
-VkInverseFFTImageFilter<TInputImage,TOutputImage>::GetSizeGreatestPrimeFactor() const
+typename VkInverseFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
+VkInverseFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
   return m_VkCommon.GetGreatestPrimeFactor();
 }

--- a/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
+++ b/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
@@ -22,6 +22,7 @@
 #include "itkImage.h"
 #include "itkRealToHalfHermitianForwardFFTImageFilter.h"
 #include "itkVkCommon.h"
+#include "itkVkGlobalConfiguration.h"
 
 namespace itk
 {
@@ -34,7 +35,7 @@ namespace itk
  * implementation is based on the VkFFT library.
  *
  * This filter is multithreaded and supports input images with sizes which are
- * divisible by primes up to 13.
+ * divisible only by primes up to 13.
  *
  * \ingroup FourierTransform
  * \ingroup MultiThreaded
@@ -84,8 +85,24 @@ public:
 
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
 
-  itkGetMacro(DeviceID, uint64_t);
+  /** Determine whether local or global properties will be
+   *  referenced for setting up GPU acceleration.
+   *  Defaults to global so that the user can adjust default properties
+   *  in filters constructed through the ITK object factory. */
+  itkSetMacro(UseVkGlobalConfiguration, bool);
+  itkGetMacro(UseVkGlobalConfiguration, bool);
+
+  /** Local platform identifier for accelerated backend.
+   *  Ignored if `UseVkGlobalConfiguration` is true. */
   itkSetMacro(DeviceID, uint64_t);
+
+  /** Return the enumerated GPU device to use for FFT
+   *  according to current filter settings. */
+  uint64_t
+  GetDeviceID() const
+  {
+    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+  }
 
   SizeValueType
   GetSizeGreatestPrimeFactor() const override;
@@ -101,6 +118,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
+  bool     m_UseVkGlobalConfiguration{true};
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/include/itkVkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -66,7 +66,7 @@ VkRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::GenerateD
 
   // Mostly use defaults for VkCommon::VkGPU
   typename VkCommon::VkGPU vkGPU;
-  vkGPU.device_id = m_DeviceID;
+  vkGPU.device_id = this->GetDeviceID();
 
   // Describe this filter in VkCommon::VkParameters
   typename VkCommon::VkParameters vkParameters;
@@ -106,7 +106,10 @@ void
 VkRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "UseVkGlobalConfiguration: " << m_UseVkGlobalConfiguration << std::endl;
+  os << indent << "Local DeviceID: " << m_DeviceID << std::endl;
+  os << indent << "Global DeviceID: " << VkGlobalConfiguration::GetDeviceID() << std::endl;
+  os << indent << "Preferred DeviceID: " << this->GetDeviceID() << std::endl;
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(VkFFTBackend_SRCS
   itkVkCommon.cxx
+  itkVkGlobalConfiguration.cxx
   )
 
 itk_module_add_library(VkFFTBackend ${VkFFTBackend_SRCS})

--- a/src/itkVkGlobalConfiguration.cxx
+++ b/src/itkVkGlobalConfiguration.cxx
@@ -1,0 +1,77 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkVkGlobalConfiguration.h"
+
+#include <mutex>
+#include "itkSingleton.h"
+
+namespace itk
+{
+struct VkGlobalConfigurationGlobals
+{
+  VkGlobalConfiguration::Pointer m_Instance{nullptr};
+  std::mutex                     m_CreationLock;
+};
+
+itkGetGlobalSimpleMacro(VkGlobalConfiguration, VkGlobalConfigurationGlobals, PimplGlobals);
+
+VkGlobalConfigurationGlobals * VkGlobalConfiguration::m_PimplGlobals;
+
+VkGlobalConfiguration::Pointer
+VkGlobalConfiguration::GetInstance()
+{
+  itkInitGlobalsMacro(PimplGlobals);
+  if (!m_PimplGlobals->m_Instance)
+  {
+    m_PimplGlobals->m_CreationLock.lock();
+    // Need to make sure that during gaining access
+    // to the lock that some other thread did not
+    // initialize the singleton.
+    if (!m_PimplGlobals->m_Instance)
+    {
+      m_PimplGlobals->m_Instance = Self::New();
+      if (!m_PimplGlobals->m_Instance)
+      {
+        std::ostringstream message;
+        message << "itk::ERROR: "
+                << "VkGlobalConfiguration"
+                << " Valid VkGlobalConfiguration instance not created";
+        itk::ExceptionObject e_(__FILE__, __LINE__, message.str().c_str(), ITK_LOCATION);
+        throw e_; /* Explicit naming to work around Intel compiler bug.  */
+      }
+    }
+    m_PimplGlobals->m_CreationLock.unlock();
+  }
+  return m_PimplGlobals->m_Instance;
+}
+
+void
+VkGlobalConfiguration::SetDeviceID(const uint64_t id)
+{
+  itkInitGlobalsMacro(PimplGlobals);
+  GetInstance()->m_DeviceID = id;
+}
+
+uint64_t
+VkGlobalConfiguration::GetDeviceID()
+{
+  itkInitGlobalsMacro(PimplGlobals);
+  return GetInstance()->m_DeviceID;
+}
+
+} // namespace itk

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(VkFFTBackendTests
   itkVkForwardInverseFFTImageFilterTest.cxx
   itkVkForwardInverse1DFFTImageFilterTest.cxx
   itkVkForward1DFFTImageFilterBaselineTest.cxx
+  itkVkGlobalConfigurationTest.cxx
   itkVkHalfHermitianFFTImageFilterTest.cxx
   itkVkInverse1DFFTImageFilterBaselineTest.cxx
   )
@@ -88,3 +89,7 @@ itk_add_test(NAME itkVkFFTImageFilterFactoryTest
   COMMAND VkFFTBackendTestDriver
   itkVkFFTImageFilterFactoryTest
    )
+
+itk_add_test(NAME itkVkGlobalConfigurationTest
+  COMMAND VkFFTBackendTestDriver
+  itkVkGlobalConfigurationTest)

--- a/test/itkVkComplexToComplex1DFFTImageFilterSizesTest.cxx
+++ b/test/itkVkComplexToComplex1DFFTImageFilterSizesTest.cxx
@@ -23,6 +23,7 @@
 #include "itkCommand.h"
 #include "itkImageFileWriter.h"
 #include "itkTestingMacros.h"
+#include "itkVkGlobalConfiguration.h"
 
 namespace
 {
@@ -75,7 +76,9 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
 
     using FilterType = itk::VkComplexToComplex1DFFTImageFilter<ComplexImageType>;
     typename FilterType::Pointer filter{ FilterType::New() };
-    filter->SetDeviceID(0);
+    //filter->SetDeviceID(0);
+    itk::VkGlobalConfiguration::SetDeviceID(0);
+
 
     ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, VkComplexToComplex1DFFTImageFilter, ComplexToComplex1DFFTImageFilter);
 
@@ -136,7 +139,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
 
       using FilterType = itk::VkComplexToComplex1DFFTImageFilter<ComplexImageType>;
       typename FilterType::Pointer filter{ FilterType::New() };
-      filter->SetDeviceID(0);
+      //filter->SetDeviceID(0);
       filter->SetInput(image);
 
       ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());

--- a/test/itkVkGlobalConfigurationTest.cxx
+++ b/test/itkVkGlobalConfigurationTest.cxx
@@ -1,0 +1,84 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include <complex>
+
+#include "itkVkComplexToComplex1DFFTImageFilter.h"
+#include "itkVkComplexToComplexFFTImageFilter.h"
+#include "itkVkForward1DFFTImageFilter.h"
+#include "itkVkForwardFFTImageFilter.h"
+#include "itkVkHalfHermitianToRealInverseFFTImageFilter.h"
+#include "itkVkInverse1DFFTImageFilter.h"
+#include "itkVkInverseFFTImageFilter.h"
+#include "itkVkRealToHalfHermitianForwardFFTImageFilter.h"
+
+#include "itkVkGlobalConfiguration.h"
+#include "itkTestingMacros.h"
+
+// Verify FFT interface classes can be instantiated with
+// VkFFT backends through ITK object factory override methods
+
+template <typename FFTImageFilterType>
+int
+itkVkGlobalConfigurationTestProcedure()
+{
+  // Verify that we can set global configuration properties
+  itk::VkGlobalConfiguration::SetDeviceID(1);
+  ITK_TEST_SET_GET_VALUE(itk::VkGlobalConfiguration::GetDeviceID(), 1);
+
+  // Verify global configuration properties are picked up by filters by default
+
+  auto fftFilter = FFTImageFilterType::New();
+  ITK_TEST_SET_GET_VALUE(fftFilter->GetUseVkGlobalConfiguration(), true);
+  ITK_TEST_SET_GET_VALUE(fftFilter->GetDeviceID(), 1);
+  fftFilter->SetDeviceID(2);
+  ITK_TEST_SET_GET_VALUE(fftFilter->GetDeviceID(), 1);
+  itk::VkGlobalConfiguration::SetDeviceID(0);
+  ITK_TEST_SET_GET_VALUE(fftFilter->GetDeviceID(), 0);
+
+  // Verify global configuration can be ignored via filter settings
+  fftFilter->SetUseVkGlobalConfiguration(false);
+  ITK_TEST_SET_GET_VALUE(fftFilter->GetUseVkGlobalConfiguration(), false);
+  ITK_TEST_SET_GET_VALUE(fftFilter->GetDeviceID(), 2);
+  itk::VkGlobalConfiguration::SetDeviceID(0);
+  ITK_TEST_SET_GET_VALUE(fftFilter->GetDeviceID(), 2);
+  fftFilter->SetDeviceID(1);
+  ITK_TEST_SET_GET_VALUE(fftFilter->GetDeviceID(), 1);
+
+  return EXIT_SUCCESS;
+}
+
+int
+itkVkGlobalConfigurationTest(int argc, char * argv[])
+{
+  using RealImageType = itk::Image<float, 2>;
+  using ComplexImageType = itk::Image<std::complex<float>, 2>;
+
+  itkVkGlobalConfigurationTestProcedure<itk::VkComplexToComplex1DFFTImageFilter<ComplexImageType, ComplexImageType>>();
+  itkVkGlobalConfigurationTestProcedure<itk::VkComplexToComplexFFTImageFilter<ComplexImageType, ComplexImageType>>();
+  itkVkGlobalConfigurationTestProcedure<itk::VkForward1DFFTImageFilter<RealImageType, ComplexImageType>>();
+  itkVkGlobalConfigurationTestProcedure<itk::VkForwardFFTImageFilter<RealImageType, ComplexImageType>>();
+  itkVkGlobalConfigurationTestProcedure<
+    itk::VkHalfHermitianToRealInverseFFTImageFilter<ComplexImageType, RealImageType>>();
+  itkVkGlobalConfigurationTestProcedure<itk::VkInverse1DFFTImageFilter<ComplexImageType, RealImageType>>();
+  itkVkGlobalConfigurationTestProcedure<itk::VkInverseFFTImageFilter<ComplexImageType, RealImageType>>();
+  itkVkGlobalConfigurationTestProcedure<
+    itk::VkRealToHalfHermitianForwardFFTImageFilter<RealImageType, ComplexImageType>>();
+
+  return EXIT_SUCCESS;
+}

--- a/wrapping/itkVkGlobalConfiguration.wrap
+++ b/wrapping/itkVkGlobalConfiguration.wrap
@@ -1,0 +1,1 @@
+itk_wrap_simple_class("itk::VkGlobalConfiguration" POINTER)


### PR DESCRIPTION
## Summary

This PR addresses #29 by adding a global parameter to set the device/platform for acceleration.

## Overview

In #26 we seek to enable factory overrides such that VkFFT accelerated classes are the default ITK FFT implementation when available. Instantiating FFTs should be simple and adhere to the base FFT class interface with no explicit knowledge of GPU parameters:
```py
fft_filter = itk.ForwardFFTImageFilter[RealImageType, ComplexImageType].New()   # instantiates GPU backend
```

However, it is possible for the default OpenCL platform to be the wrong one. For instance, on my system the CPU is the default OpenCL platform (0) rather than the GPU (1). Each VkFFT filter already exposes an option to select a different device, but this is not accessible from the base interface without downcasting:
```py
vk_filter = itk.VkForwardFFTImageFilter[RealImageType, ComplexImageType].New()
vk_filter.SetDeviceID(1)     # OK
```
```py
base_filter = itk.ForwardFFTImageFilter[RealImageType, ComplexImageType].New()
base_filter.SetDeviceID(1)    # Error
```
The latter case matches how factory instantiation works when the FFT filter is instantiated internal to other classes. Given that the user will typically want to stick with FFT on a single GPU, it is reasonable to make this a global parameter setting. In the event that the user wants more fine-grained control over FFT platforms, it is also reasonable to keep local settings and select between the two.

## Changes
- Adds `itk::VkGlobalConfiguration` with Python wrapping to allow user to manually set global default OpenCL device. Closely follows the design of [`itkFFTWGlobalConfiguration`](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Filtering/FFT/include/itkFFTWGlobalConfiguration.h) to make use of ITK global singletons synchronized across ITK Python modules.
- Adds `m_UseVkGlobalConfiguration` member to each FFT filter to allow fine-grained control of whether global or local settings should be used when running the filter. Defaults to `true`.
- Changes `GetDeviceID` method to return either the global or local device ID based on filter settings.
- Adds test and wrappings.

## New behavior
```py
itk.VkGlobalConfiguration.SetDeviceID(1)   # if 1 == GPU in the user's environment
fft_filter = itk.VkForwardFFTImageFilter[ImageType].New()
fft_filter.SetInput(image)
fft_filter.Update()  # runs on GPU
```