### PR TITLE
ENH: Add CUDA build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ if(NOT ITK_SOURCE_DIR)
   include(itk-module-init.cmake)
 endif()
 
+set(VKFFT_BACKEND 3 CACHE STRING "0 - Vulkan, 1 - CUDA, 2 - HIP, 3 - OpenCL")
+if(${VKFFT_BACKEND} EQUAL 1)
+# pass
+elseif(${VKFFT_BACKEND} EQUAL 3)
 ## When this module is loaded by an app, load OpenCL too.
 set(VkFFTBackend_EXPORT_CODE_INSTALL "
 set(OpenCL_DIR \"${OpenCL_DIR}\")
@@ -23,10 +27,10 @@ endif()
 set(VkFFTBackend_SYSTEM_INCLUDE_DIRS ${OpenCL_INCLUDE_DIRS})
 get_filename_component(OpenCL_LIB_DIR ${OpenCL_LIBRARY} DIRECTORY)
 set(VkFFTBackend_SYSTEM_LIBRARY_DIRS ${OpenCL_LIB_DIR})
+endif()
 
 ## VkFFT dependency
 include(FetchContent)
-set(VKFFT_BACKEND 3 CACHE STRING "0 - Vulkan, 1 - CUDA, 2 - HIP, 3 - OpenCL")
 add_definitions(-DVKFFT_BACKEND=${VKFFT_BACKEND} -DCL_TARGET_OPENCL_VERSION=120)
 set(vulkan_GIT_REPOSITORY "https://github.com/DTolm/VkFFT") # original source
 set(vulkan_GIT_TAG        "3aecc219153f97aaa46e613abbf430033eb27512")

--- a/include/itkVkCommon.h
+++ b/include/itkVkCommon.h
@@ -19,6 +19,7 @@
 #define itkVkCommon_h
 
 #include "VkFFTBackendExport.h"
+#include "itkVkDefinitions.h"
 #include "itkDataObject.h"
 #include "vkFFT.h"
 
@@ -97,17 +98,27 @@ public:
 
   struct VkGPU
   {
+#if (VKFFT_BACKEND == CUDA)
+    CUdevice device = 0;
+    CUcontext context = 0;
+#elif (VKFFT_BACKEND == OPENCL)
     cl_platform_id   platform = 0;
     cl_device_id     device = 0;
     cl_context       context = 0;
     cl_command_queue commandQueue = 0;
+#endif
     uint64_t         device_id = 0; // default value
 
     bool
     operator!=(const VkGPU & rhs) const
     {
+#  if (VKFFT_BACKEND == CUDA)
+      return this->device != rhs.device || this->context != rhs.context ||
+          this->device_id != rhs.device_id;
+#  elif (VKFFT_BACKEND == OPENCL)
       return this->platform != rhs.platform || this->device != rhs.device || this->context != rhs.context ||
              this->commandQueue != rhs.commandQueue || this->device_id != rhs.device_id;
+#endif
     }
   };
 

--- a/include/itkVkDefinitions.h
+++ b/include/itkVkDefinitions.h
@@ -1,0 +1,27 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkVkDefinitions_h
+#define itkVkDefinitions_h
+
+// Backend selection
+#define VULKAN 0
+#define CUDA 1
+#define HIP 2
+#define OPENCL 3
+
+#endif // itkVkDefinitions_h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,4 +4,11 @@ set(VkFFTBackend_SRCS
   )
 
 itk_module_add_library(VkFFTBackend ${VkFFTBackend_SRCS})
+
+if(${VKFFT_BACKEND} EQUAL 1)
+  find_package(CUDA 9.0 REQUIRED)
+  find_library(CUDA_NVRTC_LIB libnvrtc nvrtc HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBNVRTC_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64" /usr/lib64 /usr/local/cuda/lib64)
+	target_link_libraries(VkFFTBackend PUBLIC ${CUDA_LIBRARIES} cuda ${CUDA_NVRTC_LIB} VkFFT half)
+elseif(${VKFFT_BACKEND} EQUAL 3)
 target_link_libraries(VkFFTBackend PUBLIC ${OpenCL_LIBRARY})
+endif()


### PR DESCRIPTION
Adds support for building VkFFT classes against CUDA backend. Largely based on procedures and benchmarks developed in [VkFFT](https://github.com/DTolm/VkFFT).

Partially addresses #21. Tests are all passing locally when built against CUDA, but CI pipeline is not yet constructed

Remaining work after this PR:
- Add CUDA CI pipeline
- Package and distribute `itk-vkfftcuda` wheels via PyPi
- Verify CUDA libraries are successfully found and used when running wheels on a client system other than the system it was built on