### PR TITLE
STYLE: Check for casts that are narrowing conversions

### DIFF
--- a/include/itkVkComplexToComplex1DFFTImageFilter.h
+++ b/include/itkVkComplexToComplex1DFFTImageFilter.h
@@ -80,7 +80,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(VkComplexToComplex1DFFTImageFilter, ComplexToComplex1DFFTImageFilter);
 
-  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
+  static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 
   /** Determine whether local or global properties will be
    *  referenced for setting up GPU acceleration.
@@ -98,7 +98,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType
@@ -115,7 +115,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool     m_UseVkGlobalConfiguration{true};
+  bool     m_UseVkGlobalConfiguration{ true };
   uint64_t m_DeviceID{ 0UL };
   VkCommon m_VkCommon{};
 };

--- a/include/itkVkComplexToComplex1DFFTImageFilter.h
+++ b/include/itkVkComplexToComplex1DFFTImageFilter.h
@@ -98,7 +98,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
+    return uint64_t{ m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType

--- a/include/itkVkComplexToComplex1DFFTImageFilter.hxx
+++ b/include/itkVkComplexToComplex1DFFTImageFilter.hxx
@@ -123,7 +123,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return m_VkCommon.GetGreatestPrimeFactor();
+  return { m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkComplexToComplex1DFFTImageFilter.hxx
+++ b/include/itkVkComplexToComplex1DFFTImageFilter.hxx
@@ -123,7 +123,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return { m_VkCommon.GetGreatestPrimeFactor() };
+  return SizeValueType{ m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkComplexToComplexFFTImageFilter.h
+++ b/include/itkVkComplexToComplexFFTImageFilter.h
@@ -77,7 +77,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(VkComplexToComplexFFTImageFilter, ComplexToComplexFFTImageFilter);
 
-  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
+  static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 
   /** Determine whether local or global properties will be
    *  referenced for setting up GPU acceleration.
@@ -95,7 +95,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType
@@ -112,7 +112,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool     m_UseVkGlobalConfiguration{true};
+  bool     m_UseVkGlobalConfiguration{ true };
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkComplexToComplexFFTImageFilter.h
+++ b/include/itkVkComplexToComplexFFTImageFilter.h
@@ -95,7 +95,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
+    return uint64_t{ m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType

--- a/include/itkVkComplexToComplexFFTImageFilter.hxx
+++ b/include/itkVkComplexToComplexFFTImageFilter.hxx
@@ -120,7 +120,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return { m_VkCommon.GetGreatestPrimeFactor() };
+  return SizeValueType{ m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkComplexToComplexFFTImageFilter.hxx
+++ b/include/itkVkComplexToComplexFFTImageFilter.hxx
@@ -120,7 +120,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkComplexToComplexFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return m_VkCommon.GetGreatestPrimeFactor();
+  return { m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkForward1DFFTImageFilter.h
+++ b/include/itkVkForward1DFFTImageFilter.h
@@ -84,7 +84,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(VkForward1DFFTImageFilter, Forward1DFFTImageFilter);
 
-  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
+  static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 
   /** Determine whether local or global properties will be
    *  referenced for setting up GPU acceleration.
@@ -102,7 +102,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType
@@ -119,7 +119,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool     m_UseVkGlobalConfiguration{true};
+  bool     m_UseVkGlobalConfiguration{ true };
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkForward1DFFTImageFilter.h
+++ b/include/itkVkForward1DFFTImageFilter.h
@@ -102,7 +102,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
+    return uint64_t{ m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType

--- a/include/itkVkForward1DFFTImageFilter.hxx
+++ b/include/itkVkForward1DFFTImageFilter.hxx
@@ -118,7 +118,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkForward1DFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkForward1DFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return { m_VkCommon.GetGreatestPrimeFactor() };
+  return SizeValueType{ m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkForward1DFFTImageFilter.hxx
+++ b/include/itkVkForward1DFFTImageFilter.hxx
@@ -118,7 +118,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkForward1DFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkForward1DFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return m_VkCommon.GetGreatestPrimeFactor();
+  return { m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkForwardFFTImageFilter.h
+++ b/include/itkVkForwardFFTImageFilter.h
@@ -100,7 +100,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
+    return uint64_t{ m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType

--- a/include/itkVkForwardFFTImageFilter.h
+++ b/include/itkVkForwardFFTImageFilter.h
@@ -82,7 +82,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(VkForwardFFTImageFilter, ForwardFFTImageFilter);
 
-  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
+  static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 
   /** Determine whether local or global properties will be
    *  referenced for setting up GPU acceleration.
@@ -100,7 +100,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType
@@ -117,7 +117,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool     m_UseVkGlobalConfiguration{true};
+  bool     m_UseVkGlobalConfiguration{ true };
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkForwardFFTImageFilter.hxx
+++ b/include/itkVkForwardFFTImageFilter.hxx
@@ -116,7 +116,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkForwardFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkForwardFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return m_VkCommon.GetGreatestPrimeFactor();
+  return { m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkForwardFFTImageFilter.hxx
+++ b/include/itkVkForwardFFTImageFilter.hxx
@@ -116,7 +116,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkForwardFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkForwardFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return { m_VkCommon.GetGreatestPrimeFactor() };
+  return SizeValueType{ m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
@@ -83,7 +83,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(VkHalfHermitianToRealInverseFFTImageFilter, HalfHermitianToRealInverseFFTImageFilter);
 
-  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
+  static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 
   /** Determine whether local or global properties will be
    *  referenced for setting up GPU acceleration.
@@ -101,7 +101,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType
@@ -118,7 +118,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool     m_UseVkGlobalConfiguration{true};
+  bool     m_UseVkGlobalConfiguration{ true };
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
@@ -101,7 +101,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
+    return uint64_t{ m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType

--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -119,7 +119,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return m_VkCommon.GetGreatestPrimeFactor();
+  return { m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.hxx
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.hxx
@@ -119,7 +119,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkHalfHermitianToRealInverseFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return { m_VkCommon.GetGreatestPrimeFactor() };
+  return SizeValueType{ m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkInverse1DFFTImageFilter.h
+++ b/include/itkVkInverse1DFFTImageFilter.h
@@ -103,7 +103,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
+    return uint64_t{ m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType

--- a/include/itkVkInverse1DFFTImageFilter.h
+++ b/include/itkVkInverse1DFFTImageFilter.h
@@ -85,7 +85,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(VkInverse1DFFTImageFilter, Inverse1DFFTImageFilter);
 
-  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
+  static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 
   /** Determine whether local or global properties will be
    *  referenced for setting up GPU acceleration.
@@ -103,7 +103,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType
@@ -120,7 +120,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool     m_UseVkGlobalConfiguration{true};
+  bool     m_UseVkGlobalConfiguration{ true };
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkInverse1DFFTImageFilter.hxx
+++ b/include/itkVkInverse1DFFTImageFilter.hxx
@@ -118,7 +118,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkInverse1DFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkInverse1DFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return { m_VkCommon.GetGreatestPrimeFactor() };
+  return SizeValueType{ m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkInverse1DFFTImageFilter.hxx
+++ b/include/itkVkInverse1DFFTImageFilter.hxx
@@ -118,7 +118,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkInverse1DFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkInverse1DFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return m_VkCommon.GetGreatestPrimeFactor();
+  return { m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkInverseFFTImageFilter.h
+++ b/include/itkVkInverseFFTImageFilter.h
@@ -82,7 +82,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(VkInverseFFTImageFilter, InverseFFTImageFilter);
 
-  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
+  static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 
   /** Determine whether local or global properties will be
    *  referenced for setting up GPU acceleration.
@@ -100,7 +100,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType
@@ -117,7 +117,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool     m_UseVkGlobalConfiguration{true};
+  bool     m_UseVkGlobalConfiguration{ true };
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkInverseFFTImageFilter.h
+++ b/include/itkVkInverseFFTImageFilter.h
@@ -100,7 +100,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
+    return uint64_t{ m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType

--- a/include/itkVkInverseFFTImageFilter.hxx
+++ b/include/itkVkInverseFFTImageFilter.hxx
@@ -116,7 +116,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkInverseFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkInverseFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return { m_VkCommon.GetGreatestPrimeFactor() };
+  return SizeValueType{ m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkInverseFFTImageFilter.hxx
+++ b/include/itkVkInverseFFTImageFilter.hxx
@@ -116,7 +116,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkInverseFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkInverseFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return m_VkCommon.GetGreatestPrimeFactor();
+  return { m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
+++ b/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
@@ -101,7 +101,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
+    return uint64_t{ m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType

--- a/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
+++ b/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
@@ -83,7 +83,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(VkRealToHalfHermitianForwardFFTImageFilter, RealToHalfHermitianForwardFFTImageFilter);
 
-  static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;
+  static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 
   /** Determine whether local or global properties will be
    *  referenced for setting up GPU acceleration.
@@ -101,7 +101,7 @@ public:
   uint64_t
   GetDeviceID() const
   {
-    return m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID;
+    return { m_UseVkGlobalConfiguration ? VkGlobalConfiguration::GetDeviceID() : m_DeviceID };
   }
 
   SizeValueType
@@ -118,7 +118,7 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
 private:
-  bool     m_UseVkGlobalConfiguration{true};
+  bool     m_UseVkGlobalConfiguration{ true };
   uint64_t m_DeviceID{ 0UL };
 
   VkCommon m_VkCommon{};

--- a/include/itkVkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/include/itkVkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -116,7 +116,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return { m_VkCommon.GetGreatestPrimeFactor() };
+  return SizeValueType{ m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/include/itkVkRealToHalfHermitianForwardFFTImageFilter.hxx
+++ b/include/itkVkRealToHalfHermitianForwardFFTImageFilter.hxx
@@ -116,7 +116,7 @@ template <typename TInputImage, typename TOutputImage>
 typename VkRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::SizeValueType
 VkRealToHalfHermitianForwardFFTImageFilter<TInputImage, TOutputImage>::GetSizeGreatestPrimeFactor() const
 {
-  return m_VkCommon.GetGreatestPrimeFactor();
+  return { m_VkCommon.GetGreatestPrimeFactor() };
 }
 
 } // end namespace itk

--- a/src/itkVkCommon.cxx
+++ b/src/itkVkCommon.cxx
@@ -66,16 +66,16 @@ VkCommon::ConfigureBackend()
   cudaError_t res2{ cudaSuccess };
   res = cuInit(0);
   if (res != CUDA_SUCCESS)
-    return { VKFFT_ERROR_FAILED_TO_INITIALIZE };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_INITIALIZE };
   res2 = cudaSetDevice((int)m_VkGPU.device_id);
   if (res2 != cudaSuccess)
-    return { VKFFT_ERROR_FAILED_TO_SET_DEVICE_ID };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_SET_DEVICE_ID };
   res = cuDeviceGet(&m_VkGPU.device, (int)m_VkGPU.device_id);
   if (res != CUDA_SUCCESS)
-    return { VKFFT_ERROR_FAILED_TO_GET_DEVICE };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_GET_DEVICE };
   res = cuCtxCreate(&m_VkGPU.context, 0, (int)m_VkGPU.device);
   if (res != CUDA_SUCCESS)
-    return { VKFFT_ERROR_FAILED_TO_CREATE_CONTEXT };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_CREATE_CONTEXT };
 
 #elif (VKFFT_BACKEND == OPENCL)
   cl_int resCL{ CL_SUCCESS };
@@ -86,17 +86,17 @@ VkCommon::ConfigureBackend()
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clGetPlatformIDs returned " << resCL << std::endl;
-    return { VKFFT_ERROR_FAILED_TO_INITIALIZE };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_INITIALIZE };
   }
   std::unique_ptr<cl_platform_id[]> platformsArray{ std::make_unique<cl_platform_id[]>(numPlatforms) };
   cl_platform_id *                  platforms{ &platformsArray[0] };
   if (!platforms)
-    return { VKFFT_ERROR_MALLOC_FAILED };
+    return VkFFTResult{ VKFFT_ERROR_MALLOC_FAILED };
   resCL = clGetPlatformIDs(numPlatforms, platforms, nullptr);
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clGetPlatformIDs returned " << resCL << std::endl;
-    return { VKFFT_ERROR_FAILED_TO_INITIALIZE };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_INITIALIZE };
   }
   uint64_t k{ 0 };
   for (uint64_t j = 0; j < numPlatforms; j++)
@@ -106,12 +106,12 @@ VkCommon::ConfigureBackend()
     std::unique_ptr<cl_device_id[]> deviceListArray{ std::make_unique<cl_device_id[]>(numDevices) };
     cl_device_id *                  deviceList{ &deviceListArray[0] };
     if (!deviceList)
-      return { VKFFT_ERROR_MALLOC_FAILED };
+      return VkFFTResult{ VKFFT_ERROR_MALLOC_FAILED };
     resCL = clGetDeviceIDs(platforms[j], CL_DEVICE_TYPE_ALL, numDevices, deviceList, nullptr);
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clGetDeviceIDs returned " << resCL << std::endl;
-      return { VKFFT_ERROR_FAILED_TO_GET_DEVICE };
+      return VkFFTResult{ VKFFT_ERROR_FAILED_TO_GET_DEVICE };
     }
     for (uint64_t i = 0; i < numDevices; i++)
     {
@@ -123,13 +123,13 @@ VkCommon::ConfigureBackend()
         if (resCL != CL_SUCCESS)
         {
           std::cerr << __FILE__ "(" << __LINE__ << "): clCreateContext returned " << resCL << std::endl;
-          return { VKFFT_ERROR_FAILED_TO_CREATE_CONTEXT };
+          return VkFFTResult{ VKFFT_ERROR_FAILED_TO_CREATE_CONTEXT };
         }
         m_VkGPU.commandQueue = clCreateCommandQueue(m_VkGPU.context, m_VkGPU.device, 0, &resCL);
         if (resCL != CL_SUCCESS)
         {
           std::cerr << __FILE__ "(" << __LINE__ << "): clCreateCommandQueue returned " << resCL << std::endl;
-          return { VKFFT_ERROR_FAILED_TO_CREATE_COMMAND_QUEUE };
+          return VkFFTResult{ VKFFT_ERROR_FAILED_TO_CREATE_COMMAND_QUEUE };
         }
         k++;
       }
@@ -276,7 +276,7 @@ VkCommon::PerformFFT()
   if (resCu != cudaSuccess)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): cudaMalloc returned " << resCu << std::endl;
-    return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_ALLOCATE };
   }
 
   m_VkFFTConfiguration.buffer = reinterpret_cast<void **>(&GPUBuffer);
@@ -299,7 +299,7 @@ VkCommon::PerformFFT()
       if (resCu != cudaSuccess)
       {
         std::cerr << __FILE__ "(" << __LINE__ << "): cudaMalloc returned " << resCu << std::endl;
-        return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
+        return VkFFTResult{ VKFFT_ERROR_FAILED_TO_ALLOCATE };
       }
 
       m_VkFFTConfiguration.inputBuffer = reinterpret_cast<void **>(&inputGPUBuffer);
@@ -314,7 +314,7 @@ VkCommon::PerformFFT()
       if (resCu != cudaSuccess)
       {
         std::cerr << __FILE__ "(" << __LINE__ << "): cudaMalloc returned " << resCu << std::endl;
-        return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
+        return VkFFTResult{ VKFFT_ERROR_FAILED_TO_ALLOCATE };
       }
       m_VkFFTConfiguration.outputBuffer = reinterpret_cast<void **>(&outputGPUBuffer);
     }
@@ -326,7 +326,7 @@ VkCommon::PerformFFT()
   if (resCu != cudaSuccess)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): cudaMemcpy returned " << resCu << std::endl;
-    return { VKFFT_ERROR_FAILED_TO_COPY };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_COPY };
   }
 
 #elif (VKFFT_BACKEND == OPENCL)
@@ -348,7 +348,7 @@ VkCommon::PerformFFT()
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clCreateBuffer returned " << resCL << std::endl;
-      return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
+      return VkFFTResult{ VKFFT_ERROR_FAILED_TO_ALLOCATE };
     }
     m_VkFFTConfiguration.buffer = &GPUBuffer;
   }
@@ -360,7 +360,7 @@ VkCommon::PerformFFT()
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clCreateBuffer returned " << resCL << std::endl;
-      return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
+      return VkFFTResult{ VKFFT_ERROR_FAILED_TO_ALLOCATE };
     }
     m_VkFFTConfiguration.buffer = &GPUBuffer;
 
@@ -373,7 +373,7 @@ VkCommon::PerformFFT()
       if (resCL != CL_SUCCESS)
       {
         std::cerr << __FILE__ "(" << __LINE__ << "): clCreateBuffer returned " << resCL << std::endl;
-        return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
+        return VkFFTResult{ VKFFT_ERROR_FAILED_TO_ALLOCATE };
       }
       m_VkFFTConfiguration.inputBuffer = &inputGPUBuffer;
     }
@@ -386,7 +386,7 @@ VkCommon::PerformFFT()
       if (resCL != CL_SUCCESS)
       {
         std::cerr << __FILE__ "(" << __LINE__ << "): clCreateBuffer returned " << resCL << std::endl;
-        return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
+        return VkFFTResult{ VKFFT_ERROR_FAILED_TO_ALLOCATE };
       }
       m_VkFFTConfiguration.outputBuffer = &outputGPUBuffer;
     }
@@ -405,7 +405,7 @@ VkCommon::PerformFFT()
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clEnqueueWriteBuffer returned " << resCL << std::endl;
-    return { VKFFT_ERROR_FAILED_TO_COPY };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_COPY };
   }
 #endif
 
@@ -436,7 +436,7 @@ VkCommon::PerformFFT()
   if (resCu != cudaSuccess)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): cudaDeviceSynchronize returned " << resCu << std::endl;
-    return { VKFFT_ERROR_FAILED_TO_SYNCHRONIZE };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_SYNCHRONIZE };
   }
 
   // Copy result from GPU to CPU
@@ -445,7 +445,7 @@ VkCommon::PerformFFT()
   if (resCu != cudaSuccess)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): cudaMemcpy returned " << resCu << std::endl;
-    return { VKFFT_ERROR_FAILED_TO_COPY };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_COPY };
   }
 
   // Release mem buffers
@@ -460,7 +460,7 @@ VkCommon::PerformFFT()
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clFinish returned " << resCL << std::endl;
-    return { VKFFT_ERROR_FAILED_TO_SYNCHRONIZE };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_SYNCHRONIZE };
   }
 
   // Copy result from GPU to CPU
@@ -476,7 +476,7 @@ VkCommon::PerformFFT()
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clEnqueueReadBuffer returned " << resCL << std::endl;
-    return { VKFFT_ERROR_FAILED_TO_COPY };
+    return VkFFTResult{ VKFFT_ERROR_FAILED_TO_COPY };
   }
 
   clReleaseMemObject(inputGPUBuffer);
@@ -557,7 +557,7 @@ VkCommon::ReleaseBackend()
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clReleaseCommandQueue returned " << resCL << std::endl;
-      return { VKFFT_ERROR_FAILED_TO_RELEASE_COMMAND_QUEUE };
+      return VkFFTResult{ VKFFT_ERROR_FAILED_TO_RELEASE_COMMAND_QUEUE };
     }
   }
 
@@ -567,7 +567,7 @@ VkCommon::ReleaseBackend()
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clReleaseContext returned " << resCL << std::endl;
-      return { VKFFT_ERROR_FAILED_TO_RELEASE_COMMAND_QUEUE };
+      return VkFFTResult{ VKFFT_ERROR_FAILED_TO_RELEASE_COMMAND_QUEUE };
     }
   }
 #endif

--- a/src/itkVkCommon.cxx
+++ b/src/itkVkCommon.cxx
@@ -62,20 +62,20 @@ VkCommon::ConfigureBackend()
 {
   VkFFTResult resFFT{ VKFFT_SUCCESS };
 #if (VKFFT_BACKEND == CUDA)
-  CUresult    res = CUDA_SUCCESS;
-  cudaError_t res2 = cudaSuccess;
+  CUresult    res{ CUDA_SUCCESS };
+  cudaError_t res2{ cudaSuccess };
   res = cuInit(0);
   if (res != CUDA_SUCCESS)
-    return VKFFT_ERROR_FAILED_TO_INITIALIZE;
+    return { VKFFT_ERROR_FAILED_TO_INITIALIZE };
   res2 = cudaSetDevice((int)m_VkGPU.device_id);
   if (res2 != cudaSuccess)
-    return VKFFT_ERROR_FAILED_TO_SET_DEVICE_ID;
+    return { VKFFT_ERROR_FAILED_TO_SET_DEVICE_ID };
   res = cuDeviceGet(&m_VkGPU.device, (int)m_VkGPU.device_id);
   if (res != CUDA_SUCCESS)
-    return VKFFT_ERROR_FAILED_TO_GET_DEVICE;
+    return { VKFFT_ERROR_FAILED_TO_GET_DEVICE };
   res = cuCtxCreate(&m_VkGPU.context, 0, (int)m_VkGPU.device);
   if (res != CUDA_SUCCESS)
-    return VKFFT_ERROR_FAILED_TO_CREATE_CONTEXT;
+    return { VKFFT_ERROR_FAILED_TO_CREATE_CONTEXT };
 
 #elif (VKFFT_BACKEND == OPENCL)
   cl_int resCL{ CL_SUCCESS };
@@ -86,17 +86,17 @@ VkCommon::ConfigureBackend()
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clGetPlatformIDs returned " << resCL << std::endl;
-    return VKFFT_ERROR_FAILED_TO_INITIALIZE;
+    return { VKFFT_ERROR_FAILED_TO_INITIALIZE };
   }
   std::unique_ptr<cl_platform_id[]> platformsArray{ std::make_unique<cl_platform_id[]>(numPlatforms) };
   cl_platform_id *                  platforms{ &platformsArray[0] };
   if (!platforms)
-    return VKFFT_ERROR_MALLOC_FAILED;
+    return { VKFFT_ERROR_MALLOC_FAILED };
   resCL = clGetPlatformIDs(numPlatforms, platforms, nullptr);
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clGetPlatformIDs returned " << resCL << std::endl;
-    return VKFFT_ERROR_FAILED_TO_INITIALIZE;
+    return { VKFFT_ERROR_FAILED_TO_INITIALIZE };
   }
   uint64_t k{ 0 };
   for (uint64_t j = 0; j < numPlatforms; j++)
@@ -106,12 +106,12 @@ VkCommon::ConfigureBackend()
     std::unique_ptr<cl_device_id[]> deviceListArray{ std::make_unique<cl_device_id[]>(numDevices) };
     cl_device_id *                  deviceList{ &deviceListArray[0] };
     if (!deviceList)
-      return VKFFT_ERROR_MALLOC_FAILED;
+      return { VKFFT_ERROR_MALLOC_FAILED };
     resCL = clGetDeviceIDs(platforms[j], CL_DEVICE_TYPE_ALL, numDevices, deviceList, nullptr);
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clGetDeviceIDs returned " << resCL << std::endl;
-      return VKFFT_ERROR_FAILED_TO_GET_DEVICE;
+      return { VKFFT_ERROR_FAILED_TO_GET_DEVICE };
     }
     for (uint64_t i = 0; i < numDevices; i++)
     {
@@ -123,13 +123,13 @@ VkCommon::ConfigureBackend()
         if (resCL != CL_SUCCESS)
         {
           std::cerr << __FILE__ "(" << __LINE__ << "): clCreateContext returned " << resCL << std::endl;
-          return VKFFT_ERROR_FAILED_TO_CREATE_CONTEXT;
+          return { VKFFT_ERROR_FAILED_TO_CREATE_CONTEXT };
         }
         m_VkGPU.commandQueue = clCreateCommandQueue(m_VkGPU.context, m_VkGPU.device, 0, &resCL);
         if (resCL != CL_SUCCESS)
         {
           std::cerr << __FILE__ "(" << __LINE__ << "): clCreateCommandQueue returned " << resCL << std::endl;
-          return VKFFT_ERROR_FAILED_TO_CREATE_COMMAND_QUEUE;
+          return { VKFFT_ERROR_FAILED_TO_CREATE_COMMAND_QUEUE };
         }
         k++;
       }
@@ -263,7 +263,7 @@ VkCommon::PerformFFT()
   VkFFTResult resFFT{ VKFFT_SUCCESS };
 
 #if (VKFFT_BACKEND == CUDA)
-  cudaError resCu = cudaSuccess;
+  cudaError resCu{ cudaSuccess };
 
   cuFloatComplex * inputGPUBuffer{ nullptr };
   cuFloatComplex * GPUBuffer{ nullptr };
@@ -276,7 +276,7 @@ VkCommon::PerformFFT()
   if (resCu != cudaSuccess)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): cudaMalloc returned " << resCu << std::endl;
-    return VKFFT_ERROR_FAILED_TO_ALLOCATE;
+    return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
   }
 
   m_VkFFTConfiguration.buffer = reinterpret_cast<void **>(&GPUBuffer);
@@ -299,7 +299,7 @@ VkCommon::PerformFFT()
       if (resCu != cudaSuccess)
       {
         std::cerr << __FILE__ "(" << __LINE__ << "): cudaMalloc returned " << resCu << std::endl;
-        return VKFFT_ERROR_FAILED_TO_ALLOCATE;
+        return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
       }
 
       m_VkFFTConfiguration.inputBuffer = reinterpret_cast<void **>(&inputGPUBuffer);
@@ -314,7 +314,7 @@ VkCommon::PerformFFT()
       if (resCu != cudaSuccess)
       {
         std::cerr << __FILE__ "(" << __LINE__ << "): cudaMalloc returned " << resCu << std::endl;
-        return VKFFT_ERROR_FAILED_TO_ALLOCATE;
+        return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
       }
       m_VkFFTConfiguration.outputBuffer = reinterpret_cast<void **>(&outputGPUBuffer);
     }
@@ -326,7 +326,7 @@ VkCommon::PerformFFT()
   if (resCu != cudaSuccess)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): cudaMemcpy returned " << resCu << std::endl;
-    return VKFFT_ERROR_FAILED_TO_COPY;
+    return { VKFFT_ERROR_FAILED_TO_COPY };
   }
 
 #elif (VKFFT_BACKEND == OPENCL)
@@ -348,7 +348,7 @@ VkCommon::PerformFFT()
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clCreateBuffer returned " << resCL << std::endl;
-      return VKFFT_ERROR_FAILED_TO_ALLOCATE;
+      return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
     }
     m_VkFFTConfiguration.buffer = &GPUBuffer;
   }
@@ -360,7 +360,7 @@ VkCommon::PerformFFT()
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clCreateBuffer returned " << resCL << std::endl;
-      return VKFFT_ERROR_FAILED_TO_ALLOCATE;
+      return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
     }
     m_VkFFTConfiguration.buffer = &GPUBuffer;
 
@@ -373,7 +373,7 @@ VkCommon::PerformFFT()
       if (resCL != CL_SUCCESS)
       {
         std::cerr << __FILE__ "(" << __LINE__ << "): clCreateBuffer returned " << resCL << std::endl;
-        return VKFFT_ERROR_FAILED_TO_ALLOCATE;
+        return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
       }
       m_VkFFTConfiguration.inputBuffer = &inputGPUBuffer;
     }
@@ -386,7 +386,7 @@ VkCommon::PerformFFT()
       if (resCL != CL_SUCCESS)
       {
         std::cerr << __FILE__ "(" << __LINE__ << "): clCreateBuffer returned " << resCL << std::endl;
-        return VKFFT_ERROR_FAILED_TO_ALLOCATE;
+        return { VKFFT_ERROR_FAILED_TO_ALLOCATE };
       }
       m_VkFFTConfiguration.outputBuffer = &outputGPUBuffer;
     }
@@ -405,7 +405,7 @@ VkCommon::PerformFFT()
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clEnqueueWriteBuffer returned " << resCL << std::endl;
-    return VKFFT_ERROR_FAILED_TO_COPY;
+    return { VKFFT_ERROR_FAILED_TO_COPY };
   }
 #endif
 
@@ -436,7 +436,7 @@ VkCommon::PerformFFT()
   if (resCu != cudaSuccess)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): cudaDeviceSynchronize returned " << resCu << std::endl;
-    return VKFFT_ERROR_FAILED_TO_SYNCHRONIZE;
+    return { VKFFT_ERROR_FAILED_TO_SYNCHRONIZE };
   }
 
   // Copy result from GPU to CPU
@@ -445,7 +445,7 @@ VkCommon::PerformFFT()
   if (resCu != cudaSuccess)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): cudaMemcpy returned " << resCu << std::endl;
-    return VKFFT_ERROR_FAILED_TO_COPY;
+    return { VKFFT_ERROR_FAILED_TO_COPY };
   }
 
   // Release mem buffers
@@ -460,7 +460,7 @@ VkCommon::PerformFFT()
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clFinish returned " << resCL << std::endl;
-    return VKFFT_ERROR_FAILED_TO_SYNCHRONIZE;
+    return { VKFFT_ERROR_FAILED_TO_SYNCHRONIZE };
   }
 
   // Copy result from GPU to CPU
@@ -476,7 +476,7 @@ VkCommon::PerformFFT()
   if (resCL != CL_SUCCESS)
   {
     std::cerr << __FILE__ "(" << __LINE__ << "): clEnqueueReadBuffer returned " << resCL << std::endl;
-    return VKFFT_ERROR_FAILED_TO_COPY;
+    return { VKFFT_ERROR_FAILED_TO_COPY };
   }
 
   clReleaseMemObject(inputGPUBuffer);
@@ -492,7 +492,8 @@ VkCommon::PerformFFT()
     // Compute complex conjugates for the R2FullH forward computation
     switch (m_VkParameters.P)
     {
-      case PrecisionEnum::FLOAT: {
+      case PrecisionEnum::FLOAT:
+      {
         using ComplexType = std::complex<float>;
         ComplexType * const outputCPUFloat{ reinterpret_cast<ComplexType *>(m_VkParameters.outputCPUBuffer) };
         for (uint64_t z = 0; z < m_VkFFTConfiguration.size[2]; ++z)
@@ -510,7 +511,8 @@ VkCommon::PerformFFT()
         }
       }
       break;
-      case PrecisionEnum::DOUBLE: {
+      case PrecisionEnum::DOUBLE:
+      {
         using ComplexType = std::complex<double>;
         ComplexType * const outputCPUDouble{ reinterpret_cast<ComplexType *>(m_VkParameters.outputCPUBuffer) };
         for (uint64_t z = 0; z < m_VkFFTConfiguration.size[2]; ++z)
@@ -555,7 +557,7 @@ VkCommon::ReleaseBackend()
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clReleaseCommandQueue returned " << resCL << std::endl;
-      return VKFFT_ERROR_FAILED_TO_RELEASE_COMMAND_QUEUE;
+      return { VKFFT_ERROR_FAILED_TO_RELEASE_COMMAND_QUEUE };
     }
   }
 
@@ -565,7 +567,7 @@ VkCommon::ReleaseBackend()
     if (resCL != CL_SUCCESS)
     {
       std::cerr << __FILE__ "(" << __LINE__ << "): clReleaseContext returned " << resCL << std::endl;
-      return VKFFT_ERROR_FAILED_TO_RELEASE_COMMAND_QUEUE;
+      return { VKFFT_ERROR_FAILED_TO_RELEASE_COMMAND_QUEUE };
     }
   }
 #endif

--- a/src/itkVkGlobalConfiguration.cxx
+++ b/src/itkVkGlobalConfiguration.cxx
@@ -24,7 +24,7 @@ namespace itk
 {
 struct VkGlobalConfigurationGlobals
 {
-  VkGlobalConfiguration::Pointer m_Instance{nullptr};
+  VkGlobalConfiguration::Pointer m_Instance{ nullptr };
   std::mutex                     m_CreationLock;
 };
 
@@ -57,7 +57,7 @@ VkGlobalConfiguration::GetInstance()
     }
     m_PimplGlobals->m_CreationLock.unlock();
   }
-  return m_PimplGlobals->m_Instance;
+  return { m_PimplGlobals->m_Instance };
 }
 
 void
@@ -71,7 +71,7 @@ uint64_t
 VkGlobalConfiguration::GetDeviceID()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  return GetInstance()->m_DeviceID;
+  return { GetInstance()->m_DeviceID };
 }
 
 } // namespace itk

--- a/src/itkVkGlobalConfiguration.cxx
+++ b/src/itkVkGlobalConfiguration.cxx
@@ -57,7 +57,7 @@ VkGlobalConfiguration::GetInstance()
     }
     m_PimplGlobals->m_CreationLock.unlock();
   }
-  return { m_PimplGlobals->m_Instance };
+  return typename VkGlobalConfiguration::Pointer{ m_PimplGlobals->m_Instance };
 }
 
 void
@@ -71,7 +71,7 @@ uint64_t
 VkGlobalConfiguration::GetDeviceID()
 {
   itkInitGlobalsMacro(PimplGlobals);
-  return { GetInstance()->m_DeviceID };
+  return uint64_t{ GetInstance()->m_DeviceID };
 }
 
 } // namespace itk

--- a/test/itkVkComplexToComplex1DFFTImageFilterBaselineTest.cxx
+++ b/test/itkVkComplexToComplex1DFFTImageFilterBaselineTest.cxx
@@ -40,12 +40,12 @@ doTest(const char * inputRealFullImage, const char * inputImaginaryFullImage, co
   using ToRealFilterType = itk::ComplexToRealImageFilter<ComplexImageType, ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  typename ReaderType::Pointer       readerReal = ReaderType::New();
-  typename ReaderType::Pointer       readerImag = ReaderType::New();
-  typename FFTType::Pointer          fft = FFTType::New();
-  typename JoinFilterType::Pointer   joinFilter = JoinFilterType::New();
-  typename ToRealFilterType::Pointer toReal = ToRealFilterType::New();
-  typename WriterType::Pointer       writer = WriterType::New();
+  typename ReaderType::Pointer       readerReal{ ReaderType::New() };
+  typename ReaderType::Pointer       readerImag{ ReaderType::New() };
+  typename FFTType::Pointer          fft{ FFTType::New() };
+  typename JoinFilterType::Pointer   joinFilter{ JoinFilterType::New() };
+  typename ToRealFilterType::Pointer toReal{ ToRealFilterType::New() };
+  typename WriterType::Pointer       writer{ WriterType::New() };
 
   readerReal->SetFileName(inputRealFullImage);
   readerImag->SetFileName(inputImaginaryFullImage);
@@ -82,7 +82,7 @@ itkVkComplexToComplex1DFFTImageFilterBaselineTest(int argc, char * argv[])
   using FFTInverseType = itk::VkComplexToComplex1DFFTImageFilter<ComplexImageType>;
 
   // Instantiate a filter to exercise basic object methods
-  typename FFTInverseType::Pointer fft = FFTInverseType::New();
+  typename FFTInverseType::Pointer fft{ FFTInverseType::New() };
   ITK_EXERCISE_BASIC_OBJECT_METHODS(fft, VkComplexToComplex1DFFTImageFilter, ComplexToComplex1DFFTImageFilter);
 
   return doTest<FFTInverseType>(argv[1], argv[2], argv[3]);

--- a/test/itkVkComplexToComplex1DFFTImageFilterSizesTest.cxx
+++ b/test/itkVkComplexToComplex1DFFTImageFilterSizesTest.cxx
@@ -68,7 +68,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
       std::cerr << std::endl;
       return EXIT_FAILURE;
     }
-    const char * outputImageFileName = argv[1];
+    const char * outputImageFileName{ argv[1] };
 
     constexpr unsigned int Dimension{ 2 };
     using ComplexType = std::complex<double>;
@@ -76,7 +76,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
 
     using FilterType = itk::VkComplexToComplex1DFFTImageFilter<ComplexImageType>;
     typename FilterType::Pointer filter{ FilterType::New() };
-    //filter->SetDeviceID(0);
+    // filter->SetDeviceID(0);
     itk::VkGlobalConfiguration::SetDeviceID(0);
 
 
@@ -123,7 +123,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
       // with less precision.
 
-      float valueTolerance = (mySize == 17 || mySize == 19) ? 1e-5 : 1e-6;
+      float valueTolerance{ (mySize == 17 || mySize == 19) ? 1e-5f : 1e-6f };
 
       size.Fill(0);
       size[0] = mySize;
@@ -139,7 +139,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
 
       using FilterType = itk::VkComplexToComplex1DFFTImageFilter<ComplexImageType>;
       typename FilterType::Pointer filter{ FilterType::New() };
-      //filter->SetDeviceID(0);
+      // filter->SetDeviceID(0);
       filter->SetInput(image);
 
       ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());

--- a/test/itkVkComplexToComplexFFTImageFilterTest.cxx
+++ b/test/itkVkComplexToComplexFFTImageFilterTest.cxx
@@ -67,7 +67,7 @@ itkVkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
       std::cerr << std::endl;
       return EXIT_FAILURE;
     }
-    const char * outputImageFileName = argv[1];
+    const char * outputImageFileName{ argv[1] };
 
     constexpr unsigned int Dimension{ 2 };
     using ComplexType = std::complex<double>;
@@ -120,7 +120,7 @@ itkVkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
       // with less precision.
 
-      float valueTolerance = (mySize == 17 || mySize == 19) ? 1e-5 : 1e-6;
+      float valueTolerance{ (mySize == 17 || mySize == 19) ? 1e-5f : 1e-6f };
 
       size.Fill(0);
       size[0] = mySize;

--- a/test/itkVkFFTImageFilterFactoryTest.cxx
+++ b/test/itkVkFFTImageFilterFactoryTest.cxx
@@ -40,14 +40,14 @@ itkVkFFTImageFilterFactoryTest(int argc, char * argv[])
   using FFTVkSubclassType = itk::VkComplexToComplex1DFFTImageFilter<ComplexImageType>;
 
   // Verify default is non-accelerated implementation
-  typename FFTBaseType::Pointer fft = FFTBaseType::New();
+  typename FFTBaseType::Pointer fft{ FFTBaseType::New() };
   FFTDefaultSubclassType *      vnlFFT = dynamic_cast<FFTDefaultSubclassType *>(fft.GetPointer());
   ITK_TEST_EXPECT_TRUE(vnlFFT != nullptr);
   ITK_EXERCISE_BASIC_OBJECT_METHODS(vnlFFT, VnlComplexToComplex1DFFTImageFilter, ComplexToComplex1DFFTImageFilter);
 
   // Register factory and verify override
   using FactoryType = itk::FFTImageFilterFactory<itk::VkComplexToComplex1DFFTImageFilter>;
-  typename FactoryType::Pointer factory = FactoryType::New();
+  typename FactoryType::Pointer factory{ FactoryType::New() };
   itk::ObjectFactoryBase::RegisterFactory(factory, itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
 
   fft = FFTBaseType::New();

--- a/test/itkVkForward1DFFTImageFilterBaselineTest.cxx
+++ b/test/itkVkForward1DFFTImageFilterBaselineTest.cxx
@@ -39,11 +39,11 @@ doTest(const char * inputImage, const char * outputImagePrefix)
   using ImaginaryFilterType = itk::ComplexToImaginaryImageFilter<ComplexImageType, ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  typename ReaderType::Pointer          reader = ReaderType::New();
-  typename FFTType::Pointer             fft = FFTType::New();
-  typename RealFilterType::Pointer      realFilter = RealFilterType::New();
-  typename ImaginaryFilterType::Pointer imaginaryFilter = ImaginaryFilterType::New();
-  typename WriterType::Pointer          writer = WriterType::New();
+  typename ReaderType::Pointer          reader{ ReaderType::New() };
+  typename FFTType::Pointer             fft{ FFTType::New() };
+  typename RealFilterType::Pointer      realFilter{ RealFilterType::New() };
+  typename ImaginaryFilterType::Pointer imaginaryFilter{ ImaginaryFilterType::New() };
+  typename WriterType::Pointer          writer{ WriterType::New() };
 
   reader->SetFileName(inputImage);
   fft->SetInput(reader->GetOutput());
@@ -83,7 +83,7 @@ itkVkForward1DFFTImageFilterBaselineTest(int argc, char * argv[])
   using ComplexImageType = typename FFTForwardType::OutputImageType;
 
   // Instantiate a filter to exercise basic object methods
-  typename FFTForwardType::Pointer fft = FFTForwardType::New();
+  typename FFTForwardType::Pointer fft{ FFTForwardType::New() };
   ITK_EXERCISE_BASIC_OBJECT_METHODS(fft, VkForward1DFFTImageFilter, Forward1DFFTImageFilter);
 
   return doTest<FFTForwardType>(argv[1], argv[2]);

--- a/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
+++ b/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
@@ -82,7 +82,7 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
       // with less precision.
-      float valueTolerance = (mySize == 17 || mySize == 19) ? 1e-5 : 1e-6;
+      float valueTolerance{ (mySize == 17 || mySize == 19) ? 1e-5f : 1e-6f };
 
       size.Fill(0);
       size[0] = mySize;
@@ -121,60 +121,59 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
       inverseFilter->SetDeviceID(0);
       inverseFilter->SetInput(complexImage);
 
-        bool thisTestPassed{ true };
-        forwardFilter->Update();
-        typename ComplexImageType::Pointer        output{ forwardFilter->GetOutput() };
-        const typename ComplexImageType::SizeType outputSize{ output->GetLargestPossibleRegion().GetSize() };
-        if (outputSize[0] != mySize)
+      bool thisTestPassed{ true };
+      forwardFilter->Update();
+      typename ComplexImageType::Pointer        output{ forwardFilter->GetOutput() };
+      const typename ComplexImageType::SizeType outputSize{ output->GetLargestPossibleRegion().GetSize() };
+      if (outputSize[0] != mySize)
+      {
+        std::cout << "Size is " << outputSize[0] << " but should be " << mySize << "." << std::endl;
+        thisTestPassed = false;
+      }
+      for (int i = 0; i < mySize; ++i)
+      {
+        index[0] = i;
+        if (std::abs(output->GetPixel(index) - complexSomeValue) > valueTolerance)
         {
-          std::cout << "Size is " << outputSize[0] << " but should be " << mySize << "." << std::endl;
+          std::cout << output->GetPixel(index)
+                    << ": |difference| = " << std::abs(output->GetPixel(index) - complexSomeValue) << std::endl;
           thisTestPassed = false;
         }
-        for (int i = 0; i < mySize; ++i)
-        {
-          index[0] = i;
-          if (std::abs(output->GetPixel(index) - complexSomeValue) > valueTolerance)
-          {
-            std::cout << output->GetPixel(index)
-                      << ": |difference| = " << std::abs(output->GetPixel(index) - complexSomeValue) << std::endl;
-            thisTestPassed = false;
-          }
-        }
-        std::cout << "Test " << ++testNumber << " (forward, size=" << mySize << ") ... "
-                  << (thisTestPassed ? "passed." : "failed.") << std::endl;
-        testsPassed &= thisTestPassed;
+      }
+      std::cout << "Test " << ++testNumber << " (forward, size=" << mySize << ") ... "
+                << (thisTestPassed ? "passed." : "failed.") << std::endl;
+      testsPassed &= thisTestPassed;
 
-        thisTestPassed = true;
-        inverseFilter->SetInput(output);
-        inverseFilter->Update();
-        typename RealImageType::Pointer        output2{ inverseFilter->GetOutput() };
-        const typename RealImageType::SizeType output2Size{ output2->GetLargestPossibleRegion().GetSize() };
-        if (output2Size[0] != mySize)
-        {
-          std::cout << "Size is " << output2Size[0] << " but should be " << mySize << "." << std::endl;
-          thisTestPassed = false;
-        }
-        index[0] = 0;
-        if (std::abs(output2->GetPixel(index) - realSomeValue) > valueTolerance)
+      thisTestPassed = true;
+      inverseFilter->SetInput(output);
+      inverseFilter->Update();
+      typename RealImageType::Pointer        output2{ inverseFilter->GetOutput() };
+      const typename RealImageType::SizeType output2Size{ output2->GetLargestPossibleRegion().GetSize() };
+      if (output2Size[0] != mySize)
+      {
+        std::cout << "Size is " << output2Size[0] << " but should be " << mySize << "." << std::endl;
+        thisTestPassed = false;
+      }
+      index[0] = 0;
+      if (std::abs(output2->GetPixel(index) - realSomeValue) > valueTolerance)
+      {
+        std::cout << output2->GetPixel(index)
+                  << ": |difference| = " << std::abs(output2->GetPixel(index) - realSomeValue) << std::endl;
+        thisTestPassed = false;
+      }
+      for (int i = 1; i < mySize; ++i)
+      {
+        index[0] = i;
+        if (std::abs(output2->GetPixel(index) - realZeroValue) > valueTolerance)
         {
           std::cout << output2->GetPixel(index)
-                    << ": |difference| = " << std::abs(output2->GetPixel(index) - realSomeValue) << std::endl;
+                    << ": |difference| = " << std::abs(output2->GetPixel(index) - realZeroValue) << std::endl;
           thisTestPassed = false;
         }
-        for (int i = 1; i < mySize; ++i)
-        {
-          index[0] = i;
-          if (std::abs(output2->GetPixel(index) - realZeroValue) > valueTolerance)
-          {
-            std::cout << output2->GetPixel(index)
-                      << ": |difference| = " << std::abs(output2->GetPixel(index) - realZeroValue) << std::endl;
-            thisTestPassed = false;
-          }
-        }
-        std::cout << "Test " << ++testNumber << " (inverse, size=" << mySize << ") ... "
-                  << (thisTestPassed ? "passed." : "failed.") << std::endl;
-        testsPassed &= thisTestPassed;
-      
+      }
+      std::cout << "Test " << ++testNumber << " (inverse, size=" << mySize << ") ... "
+                << (thisTestPassed ? "passed." : "failed.") << std::endl;
+      testsPassed &= thisTestPassed;
     }
   }
 

--- a/test/itkVkForwardInverseFFTImageFilterTest.cxx
+++ b/test/itkVkForwardInverseFFTImageFilterTest.cxx
@@ -83,7 +83,7 @@ itkVkForwardInverseFFTImageFilterTest(int argc, char * argv[])
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
       // with less precision.
 
-      float valueTolerance = (mySize == 17 || mySize == 19) ? 1e-5 : 1e-6;
+      float valueTolerance{ (mySize == 17 || mySize == 19) ? 1e-5f : 1e-6f };
 
       size.Fill(0);
       size[0] = mySize;

--- a/test/itkVkHalfHermitianFFTImageFilterTest.cxx
+++ b/test/itkVkHalfHermitianFFTImageFilterTest.cxx
@@ -82,11 +82,11 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
       // with less precision.
 
-      float valueTolerance = (mySize == 17 || mySize == 19) ? 1e-5 : 1e-6;
+      float valueTolerance{ (mySize == 17 || mySize == 19) ? 1e-5f : 1e-6f };
 
       size.Fill(0);
       size[0] = mySize;
-      bool xIsOdd = (mySize % 2 == 1);
+      bool xIsOdd{ mySize % 2 == 1 };
 
       typename RealImageType::Pointer realImage{ RealImageType::New() };
       realImage->SetRegions(size);
@@ -128,7 +128,7 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
       forwardFilter->Update();
       typename ComplexImageType::Pointer        output{ forwardFilter->GetOutput() };
       const typename ComplexImageType::SizeType outputSize{ output->GetLargestPossibleRegion().GetSize() };
-      const int                                 desiredOutputSize = mySize / 2 + 1;
+      const int                                 desiredOutputSize{ mySize / 2 + 1 };
       if (outputSize[0] != desiredOutputSize)
       {
         std::cout << "Size is " << outputSize[0] << " but should be " << desiredOutputSize << "." << std::endl;

--- a/test/itkVkInverse1DFFTImageFilterBaselineTest.cxx
+++ b/test/itkVkInverse1DFFTImageFilterBaselineTest.cxx
@@ -37,11 +37,11 @@ doTest(const char * inputRealFullImage, const char * inputImaginaryFullImage, co
   using JoinFilterType = itk::ComposeImageFilter<ImageType, ComplexImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  typename ReaderType::Pointer     readerReal = ReaderType::New();
-  typename ReaderType::Pointer     readerImag = ReaderType::New();
-  typename FFTType::Pointer        fft = FFTType::New();
-  typename JoinFilterType::Pointer joinFilter = JoinFilterType::New();
-  typename WriterType::Pointer     writer = WriterType::New();
+  typename ReaderType::Pointer     readerReal{ ReaderType::New() };
+  typename ReaderType::Pointer     readerImag{ ReaderType::New() };
+  typename FFTType::Pointer        fft{ FFTType::New() };
+  typename JoinFilterType::Pointer joinFilter{ JoinFilterType::New() };
+  typename WriterType::Pointer     writer{ WriterType::New() };
 
   readerReal->SetFileName(inputRealFullImage);
   readerImag->SetFileName(inputImaginaryFullImage);
@@ -76,7 +76,7 @@ itkVkInverse1DFFTImageFilterBaselineTest(int argc, char * argv[])
   using ImageType = typename FFTInverseType::OutputImageType;
 
   // Instantiate a filter to exercise basic object methods
-  typename FFTInverseType::Pointer fft = FFTInverseType::New();
+  typename FFTInverseType::Pointer fft{ FFTInverseType::New() };
   ITK_EXERCISE_BASIC_OBJECT_METHODS(fft, VkInverse1DFFTImageFilter, Inverse1DFFTImageFilter);
 
   return doTest<FFTInverseType>(argv[1], argv[2], argv[3]);


### PR DESCRIPTION
Replace constructors that use `=` with constructors that use `{...}` so that the compiler will tell us if any of them are using narrowing conversions that could potentially lose information, such as conversions between `signed` and `unsigned` ints, or conversions from `double` to `float`.