### PR TITLE
BUG: Resolve ITK remote module CMake errors and warnings on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_compile_options(VkFFT INTERFACE /wd4146 /wd4244 /wd4996)
 endif()
 
+# Cache content path so that it is available in test driver subproject
+# when built as an ITK remote module
+set(vulkan_lib_SOURCE_DIR "${vulkan_lib_SOURCE_DIR}" CACHE PATH "VkFFT content path")
+
 include_directories(SYSTEM ${vulkan_lib_SOURCE_DIR}/vkFFT)
 
 if(NOT ITK_SOURCE_DIR)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,8 @@ set(VkFFTBackendTests
   )
 
 include_directories(${VkFFTBackend_INCLUDE_DIRS})
+include_directories(SYSTEM ${vulkan_lib_SOURCE_DIR}/vkFFT)
+add_definitions(-DVKFFT_BACKEND=${VKFFT_BACKEND} -DCL_TARGET_OPENCL_VERSION=120)
 
 CreateTestDriver(VkFFTBackend
   "${VkFFTBackend-Test_LIBRARIES};${OpenCL_LIBRARY}"

--- a/test/itkVkComplexToComplex1DFFTImageFilterSizesTest.cxx
+++ b/test/itkVkComplexToComplex1DFFTImageFilterSizesTest.cxx
@@ -117,7 +117,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
     using ComplexImageType = itk::Image<ComplexType, Dimension>;
     typename ComplexImageType::SizeType size;
     // Skip trivial case where 1D image of size 1 fails.
-    for (int mySize = 2; mySize <= 20; ++mySize)
+    for (unsigned int mySize = 2; mySize <= 20; ++mySize)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -150,7 +150,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
       {
         thisTestPassed = false;
       }
-      for (int i = 0; i < mySize; ++i)
+      for (unsigned int i = 0; i < mySize; ++i)
       {
         index[0] = i;
 
@@ -180,7 +180,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
         std::cout << "|difference| = " << std::abs(output2->GetPixel(index) - someValue) << std::endl;
         thisTestPassed = false;
       }
-      for (int i = 1; i < mySize; ++i)
+      for (unsigned int i = 1; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - zeroValue) > valueTolerance)

--- a/test/itkVkComplexToComplexFFTImageFilterTest.cxx
+++ b/test/itkVkComplexToComplexFFTImageFilterTest.cxx
@@ -114,7 +114,7 @@ itkVkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
     using ComplexImageType = itk::Image<ComplexType, Dimension>;
     typename ComplexImageType::SizeType size;
     // Skip trivial case where 1D image of size 1 fails.
-    for (int mySize = 2; mySize <= 20; ++mySize)
+    for (unsigned int mySize = 2; mySize <= 20; ++mySize)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -147,7 +147,7 @@ itkVkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
       {
         thisTestPassed = false;
       }
-      for (int i = 0; i < mySize; ++i)
+      for (unsigned int i = 0; i < mySize; ++i)
       {
         index[0] = i;
 
@@ -177,7 +177,7 @@ itkVkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
         std::cout << "|difference| = " << std::abs(output2->GetPixel(index) - someValue) << std::endl;
         thisTestPassed = false;
       }
-      for (int i = 1; i < mySize; ++i)
+      for (unsigned int i = 1; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - zeroValue) > valueTolerance)

--- a/test/itkVkFFTImageFilterFactoryTest.cxx
+++ b/test/itkVkFFTImageFilterFactoryTest.cxx
@@ -30,7 +30,7 @@
 // VkFFT backends through ITK object factory override methods
 
 int
-itkVkFFTImageFilterFactoryTest(int argc, char * argv[])
+itkVkFFTImageFilterFactoryTest(int, char *[])
 {
   using PixelType = double;
   const unsigned int Dimension = 2;

--- a/test/itkVkForward1DFFTImageFilterBaselineTest.cxx
+++ b/test/itkVkForward1DFFTImageFilterBaselineTest.cxx
@@ -80,7 +80,6 @@ itkVkForward1DFFTImageFilterBaselineTest(int argc, char * argv[])
 
   using ImageType = itk::Image<PixelType, Dimension>;
   using FFTForwardType = itk::VkForward1DFFTImageFilter<ImageType>;
-  using ComplexImageType = typename FFTForwardType::OutputImageType;
 
   // Instantiate a filter to exercise basic object methods
   typename FFTForwardType::Pointer fft{ FFTForwardType::New() };

--- a/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
+++ b/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
@@ -143,7 +143,7 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
       std::cout << "Test " << ++testNumber << " (forward, size=" << mySize << ") ... "
                 << (thisTestPassed ? "passed." : "failed.") << std::endl;
       testsPassed &= thisTestPassed;
-       
+
       thisTestPassed = true;
       inverseFilter->SetInput(output);
       inverseFilter->Update();

--- a/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
+++ b/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
@@ -77,7 +77,7 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
     bool                              firstPass{ true };
 
     // Skip trivial case where 1D image of size 1 fails.
-    for (int mySize = 2; mySize <= 20; ++mySize)
+    for (unsigned int mySize = 2; mySize <= 20; ++mySize)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -130,7 +130,7 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
         std::cout << "Size is " << outputSize[0] << " but should be " << mySize << "." << std::endl;
         thisTestPassed = false;
       }
-      for (int i = 0; i < mySize; ++i)
+      for (unsigned int i = 0; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output->GetPixel(index) - complexSomeValue) > valueTolerance)
@@ -143,7 +143,7 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
       std::cout << "Test " << ++testNumber << " (forward, size=" << mySize << ") ... "
                 << (thisTestPassed ? "passed." : "failed.") << std::endl;
       testsPassed &= thisTestPassed;
-
+       
       thisTestPassed = true;
       inverseFilter->SetInput(output);
       inverseFilter->Update();
@@ -161,7 +161,7 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
                   << ": |difference| = " << std::abs(output2->GetPixel(index) - realSomeValue) << std::endl;
         thisTestPassed = false;
       }
-      for (int i = 1; i < mySize; ++i)
+      for (unsigned int i = 1; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - realZeroValue) > valueTolerance)

--- a/test/itkVkForwardInverseFFTImageFilterTest.cxx
+++ b/test/itkVkForwardInverseFFTImageFilterTest.cxx
@@ -77,7 +77,7 @@ itkVkForwardInverseFFTImageFilterTest(int argc, char * argv[])
     bool                              firstPass{ true };
 
     // Skip trivial case where 1D image of size 1 fails.
-    for (int mySize = 2; mySize <= 20; ++mySize, firstPass = false)
+    for (unsigned int mySize = 2; mySize <= 20; ++mySize, firstPass = false)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -131,7 +131,7 @@ itkVkForwardInverseFFTImageFilterTest(int argc, char * argv[])
         std::cout << "Size is " << outputSize[0] << " but should be " << mySize << "." << std::endl;
         thisTestPassed = false;
       }
-      for (int i = 0; i < mySize; ++i)
+      for (unsigned int i = 0; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output->GetPixel(index) - complexSomeValue) > valueTolerance)
@@ -162,7 +162,7 @@ itkVkForwardInverseFFTImageFilterTest(int argc, char * argv[])
                   << ": |difference| = " << std::abs(output2->GetPixel(index) - realSomeValue) << std::endl;
         thisTestPassed = false;
       }
-      for (int i = 1; i < mySize; ++i)
+      for (unsigned int i = 1; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - realZeroValue) > valueTolerance)

--- a/test/itkVkGlobalConfigurationTest.cxx
+++ b/test/itkVkGlobalConfigurationTest.cxx
@@ -64,7 +64,7 @@ itkVkGlobalConfigurationTestProcedure()
 }
 
 int
-itkVkGlobalConfigurationTest(int argc, char * argv[])
+itkVkGlobalConfigurationTest(int, char *[])
 {
   using RealImageType = itk::Image<float, 2>;
   using ComplexImageType = itk::Image<std::complex<float>, 2>;

--- a/test/itkVkHalfHermitianFFTImageFilterTest.cxx
+++ b/test/itkVkHalfHermitianFFTImageFilterTest.cxx
@@ -76,7 +76,7 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
     typename RealImageType::IndexType index;
     bool                              firstPass{ true };
     // Skip trivial case where 1D image of size 1 fails.
-    for (int mySize = 2; mySize <= 20; ++mySize, firstPass = false)
+    for (unsigned int mySize = 2; mySize <= 20; ++mySize, firstPass = false)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -128,13 +128,13 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
       forwardFilter->Update();
       typename ComplexImageType::Pointer        output{ forwardFilter->GetOutput() };
       const typename ComplexImageType::SizeType outputSize{ output->GetLargestPossibleRegion().GetSize() };
-      const int                                 desiredOutputSize{ mySize / 2 + 1 };
+      const unsigned int                                 desiredOutputSize{ mySize / 2 + 1 };
       if (outputSize[0] != desiredOutputSize)
       {
         std::cout << "Size is " << outputSize[0] << " but should be " << desiredOutputSize << "." << std::endl;
         thisTestPassed = false;
       }
-      for (int i = 0; i < desiredOutputSize; ++i)
+      for (unsigned int i = 0; i < desiredOutputSize; ++i)
       {
         index[0] = i;
         if (std::abs(output->GetPixel(index) - complexSomeValue) > valueTolerance)
@@ -166,7 +166,7 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
                   << ": |difference| = " << std::abs(output2->GetPixel(index) - realSomeValue) << std::endl;
         thisTestPassed = false;
       }
-      for (int i = 1; i < mySize; ++i)
+      for (unsigned int i = 1; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - realZeroValue) > valueTolerance)

--- a/test/itkVkHalfHermitianFFTImageFilterTest.cxx
+++ b/test/itkVkHalfHermitianFFTImageFilterTest.cxx
@@ -128,7 +128,7 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
       forwardFilter->Update();
       typename ComplexImageType::Pointer        output{ forwardFilter->GetOutput() };
       const typename ComplexImageType::SizeType outputSize{ output->GetLargestPossibleRegion().GetSize() };
-      const unsigned int                                 desiredOutputSize{ mySize / 2 + 1 };
+      const unsigned int                        desiredOutputSize{ mySize / 2 + 1 };
       if (outputSize[0] != desiredOutputSize)
       {
         std::cout << "Size is " << outputSize[0] << " but should be " << desiredOutputSize << "." << std::endl;

--- a/test/itkVkInverse1DFFTImageFilterBaselineTest.cxx
+++ b/test/itkVkInverse1DFFTImageFilterBaselineTest.cxx
@@ -73,7 +73,6 @@ itkVkInverse1DFFTImageFilterBaselineTest(int argc, char * argv[])
 
   using ComplexImageType = itk::Image<std::complex<PixelType>, Dimension>;
   using FFTInverseType = itk::VkInverse1DFFTImageFilter<ComplexImageType>;
-  using ImageType = typename FFTInverseType::OutputImageType;
 
   // Instantiate a filter to exercise basic object methods
   typename FFTInverseType::Pointer fft{ FFTInverseType::New() };


### PR DESCRIPTION
Fixes compiler errors when building ITKVkFFTBackend as a remote module for ITK. Prerequisite for [https://github.com/InsightSoftwareConsortium/ITK/pull/3363](https://github.com/InsightSoftwareConsortium/ITK/pull/3363).

Changes:
- `/test` subdirectories are managed differently when building as an ITK external module vs remote module. Makes path to VkFFT content a cached global variable and explicitly sets compile definitions in the test project subdirectory.
- ITK appears to enable additional warning flags for signedness comparison and unused parameters. Resolves compiler warnings in ITKVkFFTBackend tests.