### PR TITLE
COMP: Format code to address clang_format warnings

### DIFF
--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-
+    - uses: actions/checkout@v2
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
+      with:
+        error-message: 'Code is inconsistent with ITK Coding Style. Add the *action:ApplyClangFormat* PR label to correct.'

--- a/include/itkVkCommon.h
+++ b/include/itkVkCommon.h
@@ -64,26 +64,28 @@ public:
 
   struct VkParameters
   {
-    uint64_t X = 0; // size of fastest varying dimension
-    uint64_t Y = 1; // size of second-fastest varying dimension, if any, otherwise 1.
-    uint64_t Z = 1; // size of third-fastest varying dimension, if any, otherwise 1.
+    uint64_t X{ 0 }; // size of fastest varying dimension
+    uint64_t Y{ 1 }; // size of second-fastest varying dimension, if any, otherwise 1.
+    uint64_t Z{ 1 }; // size of third-fastest varying dimension, if any, otherwise 1.
     uint64_t omitDimension[3] = { 0,
                                   0,
                                   0 }; // disable FFT for this dimension (0 - FFT enabled, 1 - FFT disabled). Default 0.
                                        // Doesn't work for R2C dimension 0 for now. Doesn't work with convolutions.
     PrecisionEnum P = PrecisionEnum::FLOAT; // type for real numbers
-    uint64_t      B = 1;                    // Number of batches -- always 1
-    uint64_t      N = 1;                    // Number of redundant iterations, for benchmarking -- always 1.
-    FFTEnum       fft = FFTEnum::C2C;       // ComplexToComplex, RealToHalfHermetian, RealToFullHermetian
-    uint64_t      PSize = 4; // sizeof(float), sizeof(double), or sizeof(half) according to VkParameters.P.
-    DirectionEnum I =
-      DirectionEnum::FORWARD; // forward or inverse transformation. (R2HalfH inverse is aka HalfH2R, etc.)
-    NormalizationEnum normalized =
-      NormalizationEnum::UNNORMALIZED;  // Whether inverse transformation should be divided by array size
-    const void * inputCPUBuffer = 0;    // input buffer in CPU memory
-    uint64_t     inputBufferBytes = 0;  // number of bytes in inputCPUBuffer
-    void *       outputCPUBuffer = 0;   // output buffer in CPU memory
-    uint64_t     outputBufferBytes = 0; // number of bytes in outputCPUBuffer
+    uint64_t      B{ 1 };                   // Number of batches -- always 1
+    uint64_t      N{ 1 };                   // Number of redundant iterations, for benchmarking -- always 1.
+    FFTEnum       fft{ FFTEnum::C2C };      // ComplexToComplex, RealToHalfHermetian, RealToFullHermetian
+    uint64_t      PSize{ 4 }; // sizeof(float), sizeof(double), or sizeof(half) according to VkParameters.P.
+    DirectionEnum I{
+      DirectionEnum::FORWARD
+    }; // forward or inverse transformation. (R2HalfH inverse is aka HalfH2R, etc.)
+    NormalizationEnum normalized{
+      NormalizationEnum::UNNORMALIZED
+    };                                       // Whether inverse transformation should be divided by array size
+    const void * inputCPUBuffer{ nullptr };  // input buffer in CPU memory
+    uint64_t     inputBufferBytes{ 0 };      // number of bytes in inputCPUBuffer
+    void *       outputCPUBuffer{ nullptr }; // output buffer in CPU memory
+    uint64_t     outputBufferBytes{ 0 };     // number of bytes in outputCPUBuffer
 
     bool
     operator!=(const VkParameters & rhs) const
@@ -99,23 +101,22 @@ public:
   struct VkGPU
   {
 #if (VKFFT_BACKEND == CUDA)
-    CUdevice device = 0;
-    CUcontext context = 0;
+    CUdevice  device{ 0 };
+    CUcontext context{ 0 };
 #elif (VKFFT_BACKEND == OPENCL)
-    cl_platform_id   platform = 0;
-    cl_device_id     device = 0;
-    cl_context       context = 0;
-    cl_command_queue commandQueue = 0;
+    cl_platform_id   platform{ 0 };
+    cl_device_id     device{ 0 };
+    cl_context       context{ 0 };
+    cl_command_queue commandQueue{ 0 };
 #endif
-    uint64_t         device_id = 0; // default value
+    uint64_t device_id{ 0 }; // default value
 
     bool
     operator!=(const VkGPU & rhs) const
     {
-#  if (VKFFT_BACKEND == CUDA)
-      return this->device != rhs.device || this->context != rhs.context ||
-          this->device_id != rhs.device_id;
-#  elif (VKFFT_BACKEND == OPENCL)
+#if (VKFFT_BACKEND == CUDA)
+      return this->device != rhs.device || this->context != rhs.context || this->device_id != rhs.device_id;
+#elif (VKFFT_BACKEND == OPENCL)
       return this->platform != rhs.platform || this->device != rhs.device || this->context != rhs.context ||
              this->commandQueue != rhs.commandQueue || this->device_id != rhs.device_id;
 #endif

--- a/include/itkVkComplexToComplex1DFFTImageFilter.hxx
+++ b/include/itkVkComplexToComplex1DFFTImageFilter.hxx
@@ -86,7 +86,7 @@ VkComplexToComplex1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
   vkParameters.normalized = vkParameters.I == VkCommon::DirectionEnum::INVERSE
                               ? VkCommon::NormalizationEnum::NORMALIZED
                               : VkCommon::NormalizationEnum::UNNORMALIZED;
-  for (size_t dim = 0; dim < ImageDimension; ++dim)
+  for (size_t dim{ 0 }; dim < ImageDimension; ++dim)
   {
     if (this->GetDirection() != dim)
     {

--- a/include/itkVkForward1DFFTImageFilter.hxx
+++ b/include/itkVkForward1DFFTImageFilter.hxx
@@ -81,7 +81,7 @@ VkForward1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
   vkParameters.PSize = sizeof(RealType);
   vkParameters.I = VkCommon::DirectionEnum::FORWARD;
   vkParameters.normalized = VkCommon::NormalizationEnum::UNNORMALIZED;
-  for (size_t dim = 0; dim < ImageDimension; ++dim)
+  for (size_t dim{ 0 }; dim < ImageDimension; ++dim)
   {
     if (this->GetDirection() != dim)
     {

--- a/include/itkVkInverse1DFFTImageFilter.hxx
+++ b/include/itkVkInverse1DFFTImageFilter.hxx
@@ -81,7 +81,7 @@ VkInverse1DFFTImageFilter<TInputImage, TOutputImage>::GenerateData()
   vkParameters.PSize = sizeof(RealType);
   vkParameters.I = VkCommon::DirectionEnum::INVERSE;
   vkParameters.normalized = VkCommon::NormalizationEnum::NORMALIZED;
-  for (size_t dim = 0; dim < ImageDimension; ++dim)
+  for (size_t dim{ 0 }; dim < ImageDimension; ++dim)
   {
     if (this->GetDirection() != dim)
     {

--- a/src/itkVkCommon.cxx
+++ b/src/itkVkCommon.cxx
@@ -99,7 +99,7 @@ VkCommon::ConfigureBackend()
     return VkFFTResult{ VKFFT_ERROR_FAILED_TO_INITIALIZE };
   }
   uint64_t k{ 0 };
-  for (uint64_t j = 0; j < numPlatforms; j++)
+  for (uint64_t j{ 0 }; j < numPlatforms; j++)
   {
     cl_uint numDevices;
     resCL = clGetDeviceIDs(platforms[j], CL_DEVICE_TYPE_ALL, 0, nullptr, &numDevices);
@@ -113,7 +113,7 @@ VkCommon::ConfigureBackend()
       std::cerr << __FILE__ "(" << __LINE__ << "): clGetDeviceIDs returned " << resCL << std::endl;
       return VkFFTResult{ VKFFT_ERROR_FAILED_TO_GET_DEVICE };
     }
-    for (uint64_t i = 0; i < numDevices; i++)
+    for (uint64_t i{ 0 }; i < numDevices; i++)
     {
       if (k == m_VkGPU.device_id)
       {
@@ -163,7 +163,7 @@ VkCommon::ConfigureBackend()
   {
     m_VkFFTConfiguration.doublePrecision = 1;
   }
-  for (size_t dim = 0; dim < 3; ++dim)
+  for (size_t dim{ 0 }; dim < 3; ++dim)
   {
     m_VkFFTConfiguration.omitDimension[dim] = m_VkParameters.omitDimension[dim];
   }
@@ -496,9 +496,9 @@ VkCommon::PerformFFT()
       {
         using ComplexType = std::complex<float>;
         ComplexType * const outputCPUFloat{ reinterpret_cast<ComplexType *>(m_VkParameters.outputCPUBuffer) };
-        for (uint64_t z = 0; z < m_VkFFTConfiguration.size[2]; ++z)
+        for (uint64_t z{ 0 }; z < m_VkFFTConfiguration.size[2]; ++z)
         {
-          for (uint64_t y = 0; y < m_VkFFTConfiguration.size[1]; ++y)
+          for (uint64_t y{ 0 }; y < m_VkFFTConfiguration.size[1]; ++y)
           {
             const uint64_t offsetStart{ z * m_VkFFTConfiguration.bufferStride[1] +
                                         y * m_VkFFTConfiguration.bufferStride[0] };
@@ -515,9 +515,9 @@ VkCommon::PerformFFT()
       {
         using ComplexType = std::complex<double>;
         ComplexType * const outputCPUDouble{ reinterpret_cast<ComplexType *>(m_VkParameters.outputCPUBuffer) };
-        for (uint64_t z = 0; z < m_VkFFTConfiguration.size[2]; ++z)
+        for (uint64_t z{ 0 }; z < m_VkFFTConfiguration.size[2]; ++z)
         {
-          for (uint64_t y = 0; y < m_VkFFTConfiguration.size[1]; ++y)
+          for (uint64_t y{ 0 }; y < m_VkFFTConfiguration.size[1]; ++y)
           {
             const uint64_t offsetStart{ z * m_VkFFTConfiguration.bufferStride[1] +
                                         y * m_VkFFTConfiguration.bufferStride[0] };

--- a/src/itkVkFFTImageFilterInitFactory.cxx
+++ b/src/itkVkFFTImageFilterInitFactory.cxx
@@ -36,7 +36,8 @@ VkFFTImageFilterInitFactory::VkFFTImageFilterInitFactory()
   VkFFTImageFilterInitFactory::RegisterFactories();
 }
 
-void VkFFTImageFilterInitFactory::RegisterFactories()
+void
+VkFFTImageFilterInitFactory::RegisterFactories()
 {
   itk::ObjectFactoryBase::RegisterFactory(FFTImageFilterFactory<VkComplexToComplex1DFFTImageFilter>::New(),
                                           itk::ObjectFactoryEnums::InsertionPosition::INSERT_AT_FRONT);
@@ -59,7 +60,7 @@ void VkFFTImageFilterInitFactory::RegisterFactories()
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
 void VkFFTBackend_EXPORT
-VkFFTImageFilterInitFactoryRegister__Private()
+     VkFFTImageFilterInitFactoryRegister__Private()
 {
   VkFFTImageFilterInitFactory::RegisterFactories();
 }

--- a/test/itkVkComplexToComplex1DFFTImageFilterBaselineTest.cxx
+++ b/test/itkVkComplexToComplex1DFFTImageFilterBaselineTest.cxx
@@ -77,7 +77,7 @@ itkVkComplexToComplex1DFFTImageFilterBaselineTest(int argc, char * argv[])
   }
 
   using PixelType = double;
-  const unsigned int Dimension = 2;
+  const unsigned int Dimension{ 2 };
   using ComplexImageType = itk::Image<std::complex<PixelType>, Dimension>;
   using FFTInverseType = itk::VkComplexToComplex1DFFTImageFilter<ComplexImageType>;
 

--- a/test/itkVkComplexToComplex1DFFTImageFilterSizesTest.cxx
+++ b/test/itkVkComplexToComplex1DFFTImageFilterSizesTest.cxx
@@ -91,7 +91,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
 
     typename ShowProgress::Pointer showProgress{ ShowProgress::New() };
 
-    for (int i = 0; i < 2; ++i)
+    for (int i{ 0 }; i < 2; ++i)
     {
       image->FillBuffer(1.2f);
       image->FillBuffer(1.1f);
@@ -117,7 +117,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
     using ComplexImageType = itk::Image<ComplexType, Dimension>;
     typename ComplexImageType::SizeType size;
     // Skip trivial case where 1D image of size 1 fails.
-    for (unsigned int mySize = 2; mySize <= 20; ++mySize)
+    for (unsigned int mySize{ 2 }; mySize <= 20; ++mySize)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -150,7 +150,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
       {
         thisTestPassed = false;
       }
-      for (unsigned int i = 0; i < mySize; ++i)
+      for (unsigned int i{ 0 }; i < mySize; ++i)
       {
         index[0] = i;
 
@@ -180,7 +180,7 @@ itkVkComplexToComplex1DFFTImageFilterSizesTest(int argc, char * argv[])
         std::cout << "|difference| = " << std::abs(output2->GetPixel(index) - someValue) << std::endl;
         thisTestPassed = false;
       }
-      for (unsigned int i = 1; i < mySize; ++i)
+      for (unsigned int i{ 1 }; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - zeroValue) > valueTolerance)

--- a/test/itkVkComplexToComplexFFTImageFilterTest.cxx
+++ b/test/itkVkComplexToComplexFFTImageFilterTest.cxx
@@ -88,7 +88,7 @@ itkVkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
 
     typename ShowProgress::Pointer showProgress{ ShowProgress::New() };
 
-    for (int i = 0; i < 2; ++i)
+    for (int i{ 0 }; i < 2; ++i)
     {
       image->FillBuffer(1.2f);
       image->FillBuffer(1.1f);
@@ -114,7 +114,7 @@ itkVkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
     using ComplexImageType = itk::Image<ComplexType, Dimension>;
     typename ComplexImageType::SizeType size;
     // Skip trivial case where 1D image of size 1 fails.
-    for (unsigned int mySize = 2; mySize <= 20; ++mySize)
+    for (unsigned int mySize{ 2 }; mySize <= 20; ++mySize)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -147,7 +147,7 @@ itkVkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
       {
         thisTestPassed = false;
       }
-      for (unsigned int i = 0; i < mySize; ++i)
+      for (unsigned int i{ 0 }; i < mySize; ++i)
       {
         index[0] = i;
 
@@ -177,7 +177,7 @@ itkVkComplexToComplexFFTImageFilterTest(int argc, char * argv[])
         std::cout << "|difference| = " << std::abs(output2->GetPixel(index) - someValue) << std::endl;
         thisTestPassed = false;
       }
-      for (unsigned int i = 1; i < mySize; ++i)
+      for (unsigned int i{ 1 }; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - zeroValue) > valueTolerance)

--- a/test/itkVkFFTImageFilterFactoryTest.cxx
+++ b/test/itkVkFFTImageFilterFactoryTest.cxx
@@ -34,7 +34,7 @@ int
 itkVkFFTImageFilterFactoryTest(int, char *[])
 {
   using PixelType = double;
-  const unsigned int Dimension = 2;
+  const unsigned int Dimension{ 2 };
   using ComplexImageType = itk::Image<std::complex<PixelType>, Dimension>;
   using FFTBaseType = itk::ComplexToComplex1DFFTImageFilter<ComplexImageType>;
   using FFTDefaultSubclassType = itk::VnlComplexToComplex1DFFTImageFilter<ComplexImageType>;

--- a/test/itkVkForward1DFFTImageFilterBaselineTest.cxx
+++ b/test/itkVkForward1DFFTImageFilterBaselineTest.cxx
@@ -76,7 +76,7 @@ itkVkForward1DFFTImageFilterBaselineTest(int argc, char * argv[])
   }
 
   using PixelType = double;
-  const unsigned int Dimension = 2;
+  const unsigned int Dimension{ 2 };
 
   using ImageType = itk::Image<PixelType, Dimension>;
   using FFTForwardType = itk::VkForward1DFFTImageFilter<ImageType>;

--- a/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
+++ b/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
@@ -77,7 +77,7 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
     bool                              firstPass{ true };
 
     // Skip trivial case where 1D image of size 1 fails.
-    for (unsigned int mySize = 2; mySize <= 20; ++mySize)
+    for (unsigned int mySize{ 2 }; mySize <= 20; ++mySize)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -130,7 +130,7 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
         std::cout << "Size is " << outputSize[0] << " but should be " << mySize << "." << std::endl;
         thisTestPassed = false;
       }
-      for (unsigned int i = 0; i < mySize; ++i)
+      for (unsigned int i{ 0 }; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output->GetPixel(index) - complexSomeValue) > valueTolerance)
@@ -161,7 +161,7 @@ itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
                   << ": |difference| = " << std::abs(output2->GetPixel(index) - realSomeValue) << std::endl;
         thisTestPassed = false;
       }
-      for (unsigned int i = 1; i < mySize; ++i)
+      for (unsigned int i{ 1 }; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - realZeroValue) > valueTolerance)

--- a/test/itkVkForwardInverseFFTImageFilterTest.cxx
+++ b/test/itkVkForwardInverseFFTImageFilterTest.cxx
@@ -77,7 +77,7 @@ itkVkForwardInverseFFTImageFilterTest(int argc, char * argv[])
     bool                              firstPass{ true };
 
     // Skip trivial case where 1D image of size 1 fails.
-    for (unsigned int mySize = 2; mySize <= 20; ++mySize, firstPass = false)
+    for (unsigned int mySize{ 2 }; mySize <= 20; ++mySize, firstPass = false)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -131,7 +131,7 @@ itkVkForwardInverseFFTImageFilterTest(int argc, char * argv[])
         std::cout << "Size is " << outputSize[0] << " but should be " << mySize << "." << std::endl;
         thisTestPassed = false;
       }
-      for (unsigned int i = 0; i < mySize; ++i)
+      for (unsigned int i{ 0 }; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output->GetPixel(index) - complexSomeValue) > valueTolerance)
@@ -162,7 +162,7 @@ itkVkForwardInverseFFTImageFilterTest(int argc, char * argv[])
                   << ": |difference| = " << std::abs(output2->GetPixel(index) - realSomeValue) << std::endl;
         thisTestPassed = false;
       }
-      for (unsigned int i = 1; i < mySize; ++i)
+      for (unsigned int i{ 1 }; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - realZeroValue) > valueTolerance)

--- a/test/itkVkHalfHermitianFFTImageFilterTest.cxx
+++ b/test/itkVkHalfHermitianFFTImageFilterTest.cxx
@@ -76,7 +76,7 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
     typename RealImageType::IndexType index;
     bool                              firstPass{ true };
     // Skip trivial case where 1D image of size 1 fails.
-    for (unsigned int mySize = 2; mySize <= 20; ++mySize, firstPass = false)
+    for (unsigned int mySize{ 2 }; mySize <= 20; ++mySize, firstPass = false)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -134,7 +134,7 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
         std::cout << "Size is " << outputSize[0] << " but should be " << desiredOutputSize << "." << std::endl;
         thisTestPassed = false;
       }
-      for (unsigned int i = 0; i < desiredOutputSize; ++i)
+      for (unsigned int i{ 0 }; i < desiredOutputSize; ++i)
       {
         index[0] = i;
         if (std::abs(output->GetPixel(index) - complexSomeValue) > valueTolerance)
@@ -166,7 +166,7 @@ itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
                   << ": |difference| = " << std::abs(output2->GetPixel(index) - realSomeValue) << std::endl;
         thisTestPassed = false;
       }
-      for (unsigned int i = 1; i < mySize; ++i)
+      for (unsigned int i{ 1 }; i < mySize; ++i)
       {
         index[0] = i;
         if (std::abs(output2->GetPixel(index) - realZeroValue) > valueTolerance)

--- a/test/itkVkInverse1DFFTImageFilterBaselineTest.cxx
+++ b/test/itkVkInverse1DFFTImageFilterBaselineTest.cxx
@@ -69,7 +69,7 @@ itkVkInverse1DFFTImageFilterBaselineTest(int argc, char * argv[])
   }
 
   using PixelType = double;
-  const unsigned int Dimension = 2;
+  const unsigned int Dimension{ 2 };
 
   using ComplexImageType = itk::Image<std::complex<PixelType>, Dimension>;
   using FFTInverseType = itk::VkInverse1DFFTImageFilter<ComplexImageType>;


### PR DESCRIPTION
This fixes warnings about individual lines of C++ code.  However, the following warning generated by `.github/workflows/clang-format-linter.yml` remains unaddressed
```text
Run InsightSoftwareConsortium/ITKClangFormatLinterAction@master
  with:
    error-message: Code is inconsistent with ITK Coding Style.
/usr/bin/docker run --name bcf09832c3d6d9c6e47ed9a70b1d4169a3bc0_f5e03a --label 2bcf09 --workdir /github/workspace --rm -e INPUT_ERROR-MESSAGE -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_RUN_ATTEMPT -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_REF_NAME -e GITHUB_REF_PROTECTED -e GITHUB_REF_TYPE -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e GITHUB_STEP_SUMMARY -e RUNNER_OS -e RUNNER_ARCH -e RUNNER_NAME -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/ITKVkFFTBackend/ITKVkFFTBackend":"/github/workspace" 2bcf09:832c3d6d9c6e47ed9a70b1d4169a3bc0  "Code is inconsistent with ITK Coding Style."
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
error: cannot use -i when reading from stdin.
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
Error: Code is inconsistent with ITK Coding Style.
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```
