### PR TITLE
ENH: Versions as strings, not numbers, so that 3.1 != 3.10, etc.

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -8,7 +8,7 @@ env:
   opencl-icd-loader-git-tag: "v2021.04.29"
   opencl-headers-git-tag: "v2021.04.29"
   vkfft-backend: 3
-  opencl-version: 120
+  opencl-version: "120"
 
 
 jobs:
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
 
     - name: Install build dependencies
       run: |
@@ -206,13 +206,13 @@ jobs:
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "VkFFTBackend"
       shell: cmd
-      
+
   build-windows-opencl-python-packages:
     runs-on: windows-2019
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [7, 8, 9, 10]
+        python-version-minor: ["7", "8", "9", "10"]
         include:
           - c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
@@ -243,7 +243,7 @@ jobs:
         curl -L "https://data.kitware.com/api/v1/file/5bbf87ba8d777f06b91f27d6/download/grep-win.zip" -o "grep-win.zip"
         7z x grep-win.zip -o/c/P/grep -aoa -r
       shell: bash
-      
+
     - name: Download OpenCL-ICD-Loader
       run: |
         cd ..
@@ -291,7 +291,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [37, 38, 39, 310]
+        python-version: ["37", "38", "39", "310"]
 
     steps:
     - uses: actions/checkout@v2
@@ -325,7 +325,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: 'Specific XCode version'
       run: |
         sudo xcode-select -s "/Applications/Xcode_13.2.1.app"

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -13,12 +13,12 @@ jobs:
         include:
           - opencl-icd-loader-git-tag: "v2021.04.29"
             opencl-headers-git-tag: "v2021.04.29"
-            opencl-version: 120
+            opencl-version: "120"
             vkfft-backend: 3
             cmake-build-type: "MinSizeRel"
             platform-name: "ubuntu-nvidia-gpu"
             os: ubuntu-20.04
-        
+
     steps:
 
     - name: Check OpenCL Devices
@@ -28,10 +28,10 @@ jobs:
       shell: bash
 
     - uses: actions/checkout@v2
-    
+
     - name: Get specific version of CMake, Ninja
       uses: lukka/get-cmake@v3.18.3
-    
+
     - name: Download OpenCL-ICD-Loader
       run: |
         cd ..
@@ -47,14 +47,14 @@ jobs:
         cp -r OpenCL-Headers/CL ./
         popd
       shell: bash
-      
+
     - name: Download ITK
       run: |
         cd ..
         git clone https://github.com/InsightSoftwareConsortium/ITK.git
         cd ITK
         git checkout ${{ env.itk-git-tag }}
-        
+
     - name: Build OpenCL-ICD-Loader
       run: |
         cd ..
@@ -70,7 +70,7 @@ jobs:
         cd ITK-build
         cmake -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
         ninja
-    
+
     - name: Fetch CTest driver script
       run: |
         curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O


### PR DESCRIPTION
Re-writes version numbers as strings rather than as numbers in `.github/workflows/*.yml` files because 3.1 != 3.10, etc.  Nothing is broken at present but in the future as, e.g., a Python version goes from 3.8 to 3.9 to 3.10, this could end up being an unexpected problem.