### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkVkBlurringPerformanceMetric.h
+++ b/include/itkVkBlurringPerformanceMetric.h
@@ -76,7 +76,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkBlurringPerformanceMetric, LightObject);
+  itkOverrideGetNameOfClassMacro(VkBlurringPerformanceMetric);
 
   using ImageType = TImage;
   using KernelType = TKernel;

--- a/include/itkVkComplexToComplex1DFFTImageFilter.h
+++ b/include/itkVkComplexToComplex1DFFTImageFilter.h
@@ -78,7 +78,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkComplexToComplex1DFFTImageFilter, ComplexToComplex1DFFTImageFilter);
+  itkOverrideGetNameOfClassMacro(VkComplexToComplex1DFFTImageFilter);
 
   static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 

--- a/include/itkVkComplexToComplexFFTImageFilter.h
+++ b/include/itkVkComplexToComplexFFTImageFilter.h
@@ -75,7 +75,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkComplexToComplexFFTImageFilter, ComplexToComplexFFTImageFilter);
+  itkOverrideGetNameOfClassMacro(VkComplexToComplexFFTImageFilter);
 
   static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 

--- a/include/itkVkDiscreteGaussianImageFilter.h
+++ b/include/itkVkDiscreteGaussianImageFilter.h
@@ -76,7 +76,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkDiscreteGaussianImageFilter, DiscreteGaussianImageFilter);
+  itkOverrideGetNameOfClassMacro(VkDiscreteGaussianImageFilter);
 
   /** Image type information. */
   using InputImageType = typename Superclass::InputImageType;

--- a/include/itkVkFFTImageFilterInitFactory.h
+++ b/include/itkVkFFTImageFilterInitFactory.h
@@ -52,7 +52,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkFFTImageFilterInitFactory, LightObject);
+  itkOverrideGetNameOfClassMacro(VkFFTImageFilterInitFactory);
 
   /** Mimic factory interface for Python initialization  */
   static void

--- a/include/itkVkForward1DFFTImageFilter.h
+++ b/include/itkVkForward1DFFTImageFilter.h
@@ -82,7 +82,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkForward1DFFTImageFilter, Forward1DFFTImageFilter);
+  itkOverrideGetNameOfClassMacro(VkForward1DFFTImageFilter);
 
   static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 

--- a/include/itkVkForwardFFTImageFilter.h
+++ b/include/itkVkForwardFFTImageFilter.h
@@ -80,7 +80,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkForwardFFTImageFilter, ForwardFFTImageFilter);
+  itkOverrideGetNameOfClassMacro(VkForwardFFTImageFilter);
 
   static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 

--- a/include/itkVkGlobalConfiguration.h
+++ b/include/itkVkGlobalConfiguration.h
@@ -51,7 +51,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkGlobalConfiguration, LightObject);
+  itkOverrideGetNameOfClassMacro(VkGlobalConfiguration);
 
   /** Default accelerated platform identifier */
   static void

--- a/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
+++ b/include/itkVkHalfHermitianToRealInverseFFTImageFilter.h
@@ -81,7 +81,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkHalfHermitianToRealInverseFFTImageFilter, HalfHermitianToRealInverseFFTImageFilter);
+  itkOverrideGetNameOfClassMacro(VkHalfHermitianToRealInverseFFTImageFilter);
 
   static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 

--- a/include/itkVkInverse1DFFTImageFilter.h
+++ b/include/itkVkInverse1DFFTImageFilter.h
@@ -83,7 +83,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkInverse1DFFTImageFilter, Inverse1DFFTImageFilter);
+  itkOverrideGetNameOfClassMacro(VkInverse1DFFTImageFilter);
 
   static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 

--- a/include/itkVkInverseFFTImageFilter.h
+++ b/include/itkVkInverseFFTImageFilter.h
@@ -80,7 +80,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkInverseFFTImageFilter, InverseFFTImageFilter);
+  itkOverrideGetNameOfClassMacro(VkInverseFFTImageFilter);
 
   static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 

--- a/include/itkVkMultiResolutionPyramidImageFilter.h
+++ b/include/itkVkMultiResolutionPyramidImageFilter.h
@@ -88,7 +88,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkMultiResolutionPyramidImageFilter, MultiResolutionPyramidImageFilter);
+  itkOverrideGetNameOfClassMacro(VkMultiResolutionPyramidImageFilter);
 
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;

--- a/include/itkVkMultiResolutionPyramidImageFilterFactory.h
+++ b/include/itkVkMultiResolutionPyramidImageFilterFactory.h
@@ -67,7 +67,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkMultiResolutionPyramidImageFilterFactory, itk::ObjectFactoryBase);
+  itkOverrideGetNameOfClassMacro(VkMultiResolutionPyramidImageFilterFactory);
 
   /** Register one factory of this type  */
   static void

--- a/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
+++ b/include/itkVkRealToHalfHermitianForwardFFTImageFilter.h
@@ -81,7 +81,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VkRealToHalfHermitianForwardFFTImageFilter, RealToHalfHermitianForwardFFTImageFilter);
+  itkOverrideGetNameOfClassMacro(VkRealToHalfHermitianForwardFFTImageFilter);
 
   static constexpr unsigned int ImageDimension{ InputImageType::ImageDimension };
 


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
