### PR TITLE
COMP: Update CI best practices and Python 3.10+

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -343,9 +343,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - name: 'Specific XCode version'
+    - name: 'Select Xcode'
       run: |
-        sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
+        XCODE_APP=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+        sudo xcode-select -s "${XCODE_APP}/Contents/Developer"
 
     - name: Get specific version of CMake, Ninja
       uses: lukka/get-cmake@v3.22.2

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -34,7 +34,7 @@ jobs:
             cmake-build-type: "MinSizeRel"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v5
@@ -223,7 +223,7 @@ jobs:
     - name: Get specific version of CMake, Ninja
       uses: lukka/get-cmake@v3.22.2
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         path: "im"
 
@@ -303,7 +303,7 @@ jobs:
         python-version: ["37", "38", "39", "310", "311"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: 'Free up disk space'
       run: |
@@ -341,7 +341,7 @@ jobs:
       max-parallel: 2
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: 'Specific XCode version'
       run: |

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -27,7 +27,7 @@ jobs:
         if [ $(clinfo | grep "Number of devices" | awk '{print $4}') == "0" ]; then echo "Could not find OpenCL devices" && exit 1; fi
       shell: bash
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Get specific version of CMake, Ninja
       uses: lukka/get-cmake@v3.22.2

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -16,7 +16,7 @@ jobs:
           if [ $(clinfo | grep "Number of devices" | awk '{print $4}') == "0" ]; then echo "Could not find OpenCL devices" && exit 1; fi
         shell: bash
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v3
         with:
           python-version: '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "itk == 5.4.*",
 ]


### PR DESCRIPTION
Update clang-format linter, actions/checkout@v5, Python 3.10+, fix @ghcr-mirror refs.