### PR TITLE
COMP: Recover lost CI modernization from #74 (ITK 5.4.6, OpenCL ICD/headers 2025.07.22, OpenCL 3.0)

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,13 +3,27 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "v5.3.0"
-  itk-wheel-tag: "v5.3.0"
-  itk-python-package-tag: "03391ad738438661fff40bfe37a7cfabd171b9b1"
-  opencl-icd-loader-git-tag: "v2021.04.29"
-  opencl-headers-git-tag: "v2021.04.29"
+  itk-git-tag: "v5.4.6"
+  itk-wheel-tag: "v5.4.6"
+  itk-python-package-tag: "b698e92e1e4e883256cc3c261481a11b7d675b09"
+  opencl-icd-loader-git-tag: "v2025.07.22"
+  opencl-headers-git-tag: "v2025.07.22"
   vkfft-backend: 3
   opencl-version: "120"
+  # Only the modules VkFFTBackend DEPENDS/COMPILE_DEPENDS/TEST_DEPENDS on;
+  # transitive dependencies are auto-enabled by ITK.
+  itk-minimal-modules: >-
+    -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF
+    -DModule_ITKRegistrationCommon:BOOL=ON
+    -DModule_ITKConvolution:BOOL=ON
+    -DModule_ITKFFT:BOOL=ON
+    -DModule_ITKStatistics:BOOL=ON
+    -DModule_ITKSmoothing:BOOL=ON
+    -DModule_ITKImageSources:BOOL=ON
+    -DModule_ITKTestKernel:BOOL=ON
+    -DModule_ITKIOImageBase:BOOL=ON
+    -DModule_ITKImageCompose:BOOL=ON
+    -DModule_ITKImageIntensity:BOOL=ON
 
 
 jobs:
@@ -18,7 +32,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-14]
+        os: [ubuntu-24.04, windows-2022, macos-15]
         include:
           - os: ubuntu-24.04
             c-compiler: "gcc"
@@ -28,7 +42,7 @@ jobs:
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
-          - os: macos-14
+          - os: macos-15
             c-compiler: "clang"
             cxx-compiler: "clang++"
             cmake-build-type: "MinSizeRel"
@@ -47,10 +61,10 @@ jobs:
         python -m pip install ninja
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@latest
 
     - name: Download OpenCL-SDK
-      if: matrix.os == 'macos-14'
+      if: matrix.os == 'macos-15'
       run: |
         cd ..
         git clone --recursive https://github.com/KhronosGroup/OpenCL-SDK.git
@@ -73,12 +87,27 @@ jobs:
         popd
       shell: bash
 
-    - name: Install pocl
-      if: matrix.os != 'windows-2022'
+    - name: Install pocl (Linux, via conda-forge)
+      if: matrix.os == 'ubuntu-24.04'
       run: |
+        # Accept Anaconda's repo.anaconda.com ToS for main/r so the
+        # non-interactive solver does not refuse with CondaToSNonInteractiveError.
+        # The pocl install itself comes from conda-forge.
+        sudo conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+        sudo conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
         sudo conda config --add channels conda-forge
         sudo conda config --set channel_priority strict
-        sudo conda install -c conda-forge pocl
+        sudo conda install -y -c conda-forge pocl
+      shell: bash
+
+    - name: Install pocl (macOS, via Homebrew)
+      if: matrix.os == 'macos-15'
+      run: |
+        # Conda is not on sudo's PATH on macos-15 runner images, so the
+        # Linux conda-forge path does not work here. Homebrew's pocl
+        # formula provides an equivalent CPU OpenCL ICD.
+        brew update
+        brew install pocl
       shell: bash
 
     - name: Download ITK
@@ -89,7 +118,7 @@ jobs:
         git checkout ${{ env.itk-git-tag }}
 
     - name: Build OpenCL-SDK
-      if: matrix.os == 'macos-14'
+      if: matrix.os == 'macos-15'
       run: |
         cd ..
         mkdir OpenCL-SDK-build
@@ -124,7 +153,7 @@ jobs:
         cd ..
         mkdir ITK-build
         cd ITK-build
-        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF ${{ env.itk-minimal-modules }} -GNinja ../ITK
         ninja
 
     - name: Build ITK
@@ -134,7 +163,7 @@ jobs:
         mkdir ITK-build
         cd ITK-build
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF -GNinja ../ITK
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ matrix.c-compiler }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF ${{ env.itk-minimal-modules }} -GNinja ../ITK
         ninja
       shell: cmd
 
@@ -169,6 +198,18 @@ jobs:
           "ld: warning: text-based stub file"
           # VkFFT benchmark warning
           "warning: ignoring return value"
+          # VkFFT v1.3.x calls sprintf, deprecated on macOS SDK 15+.
+          # CDash extracts each 'note:' continuation line as a separate
+          # warning record, so the macro-name filter is what actually
+          # reduces the count to zero.
+          "deprecated-declarations"
+          "is deprecated"
+          "has been explicitly marked deprecated"
+          "__deprecated_msg"
+          "expanded from macro"
+          # VkFFT R2R kernel has '/*' inside block comments
+          "'/\\*' within block comment"
+          "-Wcomment"
           )
         set(dashboard_no_clean 1)
         set(ENV{CC} ${{ matrix.c-compiler }})
@@ -198,22 +239,60 @@ jobs:
 
     - name: Build and test
       if: matrix.os != 'windows-2022'
+      shell: bash
       run: |
+        # Point the freshly-built KhronosGroup ICD loader at conda's
+        # pocl ICD vendor file. By default the loader only checks
+        # /etc/OpenCL/vendors, but conda drops pocl.icd under its env
+        # prefix (typically /usr/share/miniconda or ~/miniconda).
+        for d in /usr/share/miniconda/etc/OpenCL/vendors \
+                 /opt/miniconda3/etc/OpenCL/vendors \
+                 "$HOME/miniconda3/etc/OpenCL/vendors" \
+                 "$CONDA_PREFIX/etc/OpenCL/vendors"; do
+          if [ -d "$d" ]; then
+            export OCL_ICD_VENDORS="$d"
+            break
+          fi
+        done
+        echo "Using OCL_ICD_VENDORS=${OCL_ICD_VENDORS:-/etc/OpenCL/vendors}"
+        ls -la "${OCL_ICD_VENDORS:-/etc/OpenCL/vendors}" 2>/dev/null || true
+        # Hosted runners ship only pocl (CPU OpenCL), which is known to
+        # diverge from real-GPU OpenCL on VkFFT-generated kernels — both
+        # baseline-image comparisons and ForwardInverse round-trips fail
+        # with large ImageError magnitudes when run under pocl. Restrict
+        # CI to non-FFT smoke tests (KWStyle, header doxygen group);
+        # functional FFT correctness is exercised on the self-hosted GPU
+        # runner via test-gpu.yml.
         ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "VkFFTBackend"
 
     - name: Build and test
       if: matrix.os == 'windows-2022'
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        # Hosted runners ship only pocl (CPU OpenCL), which is known to
+        # diverge from real-GPU OpenCL on VkFFT-generated kernels — both
+        # baseline-image comparisons and ForwardInverse round-trips fail
+        # with large ImageError magnitudes when run under pocl. Restrict
+        # CI to non-FFT smoke tests (KWStyle, header doxygen group);
+        # functional FFT correctness is exercised on the self-hosted GPU
+        # runner via test-gpu.yml.
         ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "VkFFTBackend"
       shell: cmd
 
   build-windows-opencl-python-packages:
+    # DISABLED — building Python wheels for ITK 6.0b02 on Windows requires
+    # ITKPythonBuilds-windows.zip to ship a castxml wrapping config that
+    # uses -std:c++17. The current v6.0b02 archive still passes
+    # -std:c++14 to castxml, which can't parse ITK 6's C++17 CTAD
+    # deduction guide in Modules/Core/Common/include/itkArray.h:217
+    # ("error: a type specifier is required for all declarations").
+    # Re-enable once ITKPythonBuilds-windows ships the std bump.
+    if: false
     runs-on: windows-2022
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: ["9", "10", "11"]
+        python-version-minor: ["10", "11"]
         include:
           - c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
@@ -221,7 +300,7 @@ jobs:
 
     steps:
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@latest
 
     - uses: actions/checkout@v5
       with:
@@ -296,11 +375,17 @@ jobs:
         path: ../../im/dist
 
   build-linux-opencl-python-packages:
+    # DISABLED — all three Python wheel jobs (linux, macos, windows) are
+    # gated off in this PR while upstream ITKPythonBuilds and ITKPythonPackage
+    # release-5.4 catch up to ITK 6.x. Re-enable as a follow-up PR once
+    # InsightSoftwareConsortium/ITKPythonBuilds#3 (and the linux dockcross
+    # image regression) are addressed.
+    if: false
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 2
       matrix:
-        python-version: ["37", "38", "39", "310", "311"]
+        python-version: ["310", "311"]
 
     steps:
     - uses: actions/checkout@v5
@@ -336,7 +421,15 @@ jobs:
         path: dist
 
   build-macos-opencl-python-packages:
-    runs-on: macos-14
+    # DISABLED — same root cause as build-windows-opencl-python-packages:
+    # ITKPythonBuilds-macosx-arm64.tar.zst v6.0b02 ships a pre-built ITK
+    # configured with CMAKE_CXX_STANDARD=14, so building ITK-source wheels
+    # against it fails on C++17-only standard-library names
+    # (std::is_convertible_v, std::is_same_v, ...). See
+    # InsightSoftwareConsortium/ITKPythonBuilds#3. Re-enable once
+    # ITKPythonBuilds ships a release with CMAKE_CXX_STANDARD>=17.
+    if: false
+    runs-on: macos-15
     strategy:
       max-parallel: 2
 
@@ -349,11 +442,19 @@ jobs:
         sudo xcode-select -s "${XCODE_APP}/Contents/Developer"
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@latest
 
     - name: 'Fetch build script'
       run: |
         curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/${{ env.itk-python-package-tag }}/scripts/macpython-download-cache-and-build-module-wheels.sh -O
+        # Upstream v6.0b02 ships a for-loop bug:
+        #   for version in "$PYTHON_VERSIONS"; do ... ITK-${version}-macosx* ...
+        # The quotes around $PYTHON_VERSIONS cause one iteration with the
+        # full space-separated string, so gtar gets "ITK-3.10 3.11-macosx*"
+        # (or "ITK--macosx*" when empty) and fails. Unquote so the loop
+        # iterates word-by-word.
+        sed -i.bak 's/for version in "\$PYTHON_VERSIONS"/for version in $PYTHON_VERSIONS/' \
+          macpython-download-cache-and-build-module-wheels.sh
         chmod u+x macpython-download-cache-and-build-module-wheels.sh
 
     - name: 'Build 🐍 Python 📦 package'
@@ -361,7 +462,7 @@ jobs:
         export ITK_PACKAGE_VERSION=${{ env.itk-wheel-tag }}
         export ITKPYTHONPACKAGE_TAG=${{ env.itk-python-package-tag }}
         export MACOSX_DEPLOYMENT_TARGET=14
-        ./macpython-download-cache-and-build-module-wheels.sh
+        ./macpython-download-cache-and-build-module-wheels.sh 3.10 3.11
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v4
@@ -378,7 +479,7 @@ jobs:
 
     steps:
     - name: Download Python Packages
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
 
     - name: Prepare packages for upload
       run: |

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -279,6 +279,112 @@ jobs:
         ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "VkFFTBackend"
       shell: cmd
 
+  build-backend:
+    name: build-backend (${{ matrix.backend-name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            backend: 1
+            backend-name: CUDA
+            c-compiler: "gcc"
+            cxx-compiler: "g++"
+          - os: ubuntu-24.04
+            backend: 4
+            backend-name: LevelZero
+            c-compiler: "gcc"
+            cxx-compiler: "g++"
+          - os: macos-15
+            backend: 5
+            backend-name: Metal
+            c-compiler: "clang"
+            cxx-compiler: "clang++"
+            run-tests: true
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ninja
+      shell: bash
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@latest
+
+    - name: Install CUDA toolkit
+      if: matrix.backend == 1
+      uses: Jimver/cuda-toolkit@v0.2.21
+      with:
+        method: network
+        sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev"]'
+        non-cuda-sub-packages: '["libcufft", "libcufft-dev"]'
+
+    - name: Build Level Zero loader and headers
+      if: matrix.backend == 4
+      run: |
+        git clone --depth 1 https://github.com/oneapi-src/level-zero.git ../level-zero
+        cmake -S ../level-zero -B ../level-zero-build -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr
+        sudo cmake --build ../level-zero-build --target install
+        echo "LEVEL_ZERO_ROOT=/usr" >> "$GITHUB_ENV"
+      shell: bash
+
+    - name: Download ITK
+      run: |
+        git clone https://github.com/InsightSoftwareConsortium/ITK.git ../ITK
+        git -C ../ITK checkout ${{ env.itk-git-tag }}
+      shell: bash
+
+    - name: Build minimal ITK (module dependencies only, no tests)
+      run: |
+        cmake -S ../ITK -B ../ITK-build -GNinja \
+          -DCMAKE_C_COMPILER="${{ matrix.c-compiler }}" \
+          -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" \
+          -DCMAKE_BUILD_TYPE=MinSizeRel \
+          -DBUILD_SHARED_LIBS=ON \
+          -DBUILD_TESTING=OFF \
+          ${{ env.itk-minimal-modules }}
+        cmake --build ../ITK-build
+      shell: bash
+
+    - name: Configure VkFFTBackend (VKFFT_BACKEND=${{ matrix.backend }})
+      run: |
+        extra_args=()
+        if [ "${{ matrix.backend }}" = "1" ]; then
+          # No GPU on the runner: link against the CUDA driver stub.
+          extra_args+=("-DCMAKE_SHARED_LINKER_FLAGS=-L${CUDA_PATH}/lib64/stubs")
+          extra_args+=("-DCUDA_USE_STATIC_CUDA_RUNTIME=OFF")
+        fi
+        cmake -S . -B ../module-build -GNinja \
+          -DCMAKE_C_COMPILER="${{ matrix.c-compiler }}" \
+          -DCMAKE_CXX_COMPILER="${{ matrix.cxx-compiler }}" \
+          -DCMAKE_BUILD_TYPE=MinSizeRel \
+          -DBUILD_SHARED_LIBS=ON \
+          -DBUILD_TESTING=${{ matrix.run-tests && 'ON' || 'OFF' }} \
+          -DITK_DIR="$(cd ../ITK-build && pwd)" \
+          -DVKFFT_BACKEND=${{ matrix.backend }} \
+          "${extra_args[@]}"
+      shell: bash
+
+    - name: Compile VkFFTBackend
+      run: cmake --build ../module-build
+      shell: bash
+
+    - name: Run tests
+      if: matrix.run-tests
+      run: ctest --test-dir ../module-build --output-on-failure -j 2
+      shell: bash
+
   build-windows-opencl-python-packages:
     # DISABLED — building Python wheels for ITK 6.0b02 on Windows requires
     # ITKPythonBuilds-windows.zip to ship a castxml wrapping config that

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -9,7 +9,7 @@ env:
   opencl-icd-loader-git-tag: "v2025.07.22"
   opencl-headers-git-tag: "v2025.07.22"
   vkfft-backend: 3
-  opencl-version: "120"
+  opencl-version: "300"
   # Only the modules VkFFTBackend DEPENDS/COMPILE_DEPENDS/TEST_DEPENDS on;
   # transitive dependencies are auto-enabled by ITK.
   itk-minimal-modules: >-

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -34,18 +34,25 @@ jobs:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
         include:
+          # ctest-filter: ubuntu's conda pocl is verified to compute the
+          # capped FFT subset correctly, so it runs lint + PoclSafe. windows
+          # installs no OpenCL ICD and macOS pocl is unverified, so they run
+          # the lint smoke tests only.
           - os: ubuntu-24.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "MinSizeRel"
+            ctest-filter: "VkFFTBackend|PoclSafe"
           - os: windows-2022
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
+            ctest-filter: "VkFFTBackend"
           - os: macos-15
             c-compiler: "clang"
             cxx-compiler: "clang++"
             cmake-build-type: "MinSizeRel"
+            ctest-filter: "VkFFTBackend"
 
     steps:
     - uses: actions/checkout@v5
@@ -256,27 +263,23 @@ jobs:
         done
         echo "Using OCL_ICD_VENDORS=${OCL_ICD_VENDORS:-/etc/OpenCL/vendors}"
         ls -la "${OCL_ICD_VENDORS:-/etc/OpenCL/vendors}" 2>/dev/null || true
-        # Hosted runners ship only pocl (CPU OpenCL), which is known to
-        # diverge from real-GPU OpenCL on VkFFT-generated kernels — both
-        # baseline-image comparisons and ForwardInverse round-trips fail
-        # with large ImageError magnitudes when run under pocl. Restrict
-        # CI to non-FFT smoke tests (KWStyle, header doxygen group);
-        # functional FFT correctness is exercised on the self-hosted GPU
-        # runner via test-gpu.yml.
-        ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "VkFFTBackend"
+        # Hosted runners ship only pocl (CPU OpenCL), which diverges from
+        # real-GPU OpenCL on VkFFT's larger Bluestein kernels (size-19 inverse)
+        # and on the stored-baseline image comparisons. Run the lint smoke
+        # tests plus the pocl-safe FFT round-trip subset (capped at size 16);
+        # full-size and baseline FFT correctness run on the GPU runner.
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "${{ matrix.ctest-filter }}"
 
     - name: Build and test
       if: matrix.os == 'windows-2022'
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        # Hosted runners ship only pocl (CPU OpenCL), which is known to
-        # diverge from real-GPU OpenCL on VkFFT-generated kernels — both
-        # baseline-image comparisons and ForwardInverse round-trips fail
-        # with large ImageError magnitudes when run under pocl. Restrict
-        # CI to non-FFT smoke tests (KWStyle, header doxygen group);
-        # functional FFT correctness is exercised on the self-hosted GPU
-        # runner via test-gpu.yml.
-        ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "VkFFTBackend"
+        # Hosted runners ship only pocl (CPU OpenCL), which diverges from
+        # real-GPU OpenCL on VkFFT's larger Bluestein kernels (size-19 inverse)
+        # and on the stored-baseline image comparisons. Run the lint smoke
+        # tests plus the pocl-safe FFT round-trip subset (capped at size 16);
+        # full-size and baseline FFT correctness run on the GPU runner.
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake -R "${{ matrix.ctest-filter }}"
       shell: cmd
 
   build-backend:

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - opencl-icd-loader-git-tag: "v2021.04.29"
             opencl-headers-git-tag: "v2021.04.29"
-            opencl-version: "120"
+            opencl-version: "300"
             vkfft-backend: 3
             cmake-build-type: "MinSizeRel"
             platform-name: "ubuntu-nvidia-gpu"

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -1,12 +1,16 @@
 name: Test GPU
 
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   itk-git-tag: "abf5fa10522a36bc51f42f20f426a622f42ed90d"
 
 jobs:
   build-test-gpu:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'gpu-ci')
     runs-on: [self-hosted, gpu]
     strategy:
       matrix:

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -1,9 +1,13 @@
 name: Notebook tests
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   nbmake:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'gpu-ci')
     runs-on: [self-hosted, notebook-gpu]
     name: Test notebooks with nbmake
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,10 @@ elseif(VKFFT_BACKEND EQUAL 4)
   if(NOT LevelZero_INCLUDE_DIR OR NOT LevelZero_LIBRARY)
     message(FATAL_ERROR "VKFFT_BACKEND=4 (Level Zero) requires the oneAPI Level Zero loader (ze_loader) and headers (level_zero/ze_api.h). Install the 'level-zero' package or set LEVEL_ZERO_ROOT.")
   endif()
-  list(APPEND VkFFTBackend_SYSTEM_INCLUDE_DIRS ${LevelZero_INCLUDE_DIR})
+  # VkFFT includes <ze_api.h> bare; this module uses <level_zero/ze_api.h> — both dirs needed.
+  list(APPEND VkFFTBackend_SYSTEM_INCLUDE_DIRS
+    ${LevelZero_INCLUDE_DIR}
+    ${LevelZero_INCLUDE_DIR}/level_zero)
   list(APPEND VkFFTBackend_SYSTEM_LIBRARIES ${LevelZero_LIBRARY})
 
   set(VkFFTBackend_EXPORT_CODE_INSTALL "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,8 @@ if(VKFFT_BACKEND EQUAL 1)
   find_package(CUDAToolkit REQUIRED)
   list(APPEND VkFFTBackend_SYSTEM_INCLUDE_DIRS ${CUDAToolkit_INCLUDE_DIRS})
 elseif(VKFFT_BACKEND EQUAL 3)
-  add_compile_definitions(CL_TARGET_OPENCL_VERSION=120)
+  set(CL_TARGET_OPENCL_VERSION 300 CACHE STRING "OpenCL API version to target (e.g. 120, 300)")
+  add_compile_definitions(CL_TARGET_OPENCL_VERSION=${CL_TARGET_OPENCL_VERSION})
 
   ## When this module is loaded by an app, load OpenCL too.
   set(VkFFTBackend_EXPORT_CODE_INSTALL "

--- a/include/itkVkDefinitions.h
+++ b/include/itkVkDefinitions.h
@@ -26,4 +26,12 @@
 #define LEVEL_ZERO 4
 #define METAL 5
 
+// Defensive default: when VKFFT_BACKEND is not set on the command line
+// (e.g. castxml wrapping invocations that bypass our top-level
+// add_compile_definitions), fall back to OpenCL so vkFFT.h does not
+// take the Vulkan branch and try to #include <vulkan/vulkan.h>.
+#ifndef VKFFT_BACKEND
+#  define VKFFT_BACKEND OPENCL
+#endif
+
 #endif // itkVkDefinitions_h

--- a/itk-module-init.cmake
+++ b/itk-module-init.cmake
@@ -8,8 +8,14 @@ if(${VKFFT_BACKEND} EQUAL 1)
 elseif(${VKFFT_BACKEND} EQUAL 3)
   find_package(OpenCL REQUIRED)
 elseif(${VKFFT_BACKEND} EQUAL 4)
-  find_path(LevelZero_INCLUDE_DIR NAMES level_zero/ze_api.h)
-  find_library(LevelZero_LIBRARY NAMES ze_loader)
+  find_path(LevelZero_INCLUDE_DIR
+    NAMES level_zero/ze_api.h
+    HINTS ENV LEVEL_ZERO_ROOT ENV CMPLR_ROOT
+    PATH_SUFFIXES include)
+  find_library(LevelZero_LIBRARY
+    NAMES ze_loader
+    HINTS ENV LEVEL_ZERO_ROOT ENV CMPLR_ROOT
+    PATH_SUFFIXES lib lib64 lib/x64)
   if(NOT LevelZero_INCLUDE_DIR OR NOT LevelZero_LIBRARY)
     message(FATAL_ERROR "VKFFT_BACKEND=4 (Level Zero) requires the oneAPI Level Zero loader (ze_loader) and headers (level_zero/ze_api.h).")
   endif()

--- a/src/itkVkCommon.cxx
+++ b/src/itkVkCommon.cxx
@@ -114,8 +114,22 @@ VkCommon::ConfigureBackend()
   uint64_t k{ 0 };
   for (uint64_t j{ 0 }; j < numPlatforms; j++)
   {
-    cl_uint numDevices;
+    // First probe: how many devices does this platform expose? An OpenCL
+    // platform with zero compute devices is legitimate (e.g. Apple's
+    // deprecated OpenCL framework on macOS 15 returns CL_DEVICE_NOT_FOUND
+    // for CL_DEVICE_TYPE_ALL). Skip such platforms; calling clGetDeviceIDs
+    // again with num_entries=0 would return CL_INVALID_VALUE.
+    cl_uint numDevices{ 0 };
     resCL = clGetDeviceIDs(platforms[j], CL_DEVICE_TYPE_ALL, 0, nullptr, &numDevices);
+    if (resCL == CL_DEVICE_NOT_FOUND || numDevices == 0)
+    {
+      continue;
+    }
+    if (resCL != CL_SUCCESS)
+    {
+      std::cerr << __FILE__ "(" << __LINE__ << "): clGetDeviceIDs(count) returned " << resCL << std::endl;
+      return VkFFTResult{ VKFFT_ERROR_FAILED_TO_GET_DEVICE };
+    }
     std::unique_ptr<cl_device_id[]> deviceListArray{ std::make_unique<cl_device_id[]>(numDevices) };
     cl_device_id *                  deviceList{ &deviceListArray[0] };
     if (!deviceList)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,6 +170,17 @@ itk_add_test(NAME itkVkForwardInverseFFTImageFilterTestDouble
   )
 _vkfft_disable_on_unsupported_fp64(itkVkForwardInverseFFTImageFilterTestDouble)
 
+# pocl (CPU OpenCL) computes VkFFT's size-19 Bluestein inverse incorrectly, so
+# the hosted pocl-backed leg runs the round-trip tests capped at size 16
+# (radix-2/3/5/7 plus Bluestein primes 11/13). Real GPUs run the full sweep above.
+itk_add_test(NAME itkVkForwardInverseFFTImageFilterTestFloatPoclSafe
+  COMMAND VkFFTBackendTestDriver itkVkForwardInverseFFTImageFilterTest float 16
+  )
+itk_add_test(NAME itkVkForwardInverseFFTImageFilterTestDoublePoclSafe
+  COMMAND VkFFTBackendTestDriver itkVkForwardInverseFFTImageFilterTest double 16
+  )
+_vkfft_disable_on_unsupported_fp64(itkVkForwardInverseFFTImageFilterTestDoublePoclSafe)
+
 # -----------------------------------------------------------------------------
 # ForwardInverse1DFFTImageFilterTest
 # -----------------------------------------------------------------------------
@@ -181,6 +192,14 @@ itk_add_test(NAME itkVkForwardInverse1DFFTImageFilterTestDouble
   )
 _vkfft_disable_on_unsupported_fp64(itkVkForwardInverse1DFFTImageFilterTestDouble)
 
+itk_add_test(NAME itkVkForwardInverse1DFFTImageFilterTestFloatPoclSafe
+  COMMAND VkFFTBackendTestDriver itkVkForwardInverse1DFFTImageFilterTest float 16
+  )
+itk_add_test(NAME itkVkForwardInverse1DFFTImageFilterTestDoublePoclSafe
+  COMMAND VkFFTBackendTestDriver itkVkForwardInverse1DFFTImageFilterTest double 16
+  )
+_vkfft_disable_on_unsupported_fp64(itkVkForwardInverse1DFFTImageFilterTestDoublePoclSafe)
+
 # -----------------------------------------------------------------------------
 # HalfHermitianFFTImageFilterTest
 # -----------------------------------------------------------------------------
@@ -191,6 +210,14 @@ itk_add_test(NAME itkVkHalfHermitianFFTImageFilterTestDouble
   COMMAND VkFFTBackendTestDriver itkVkHalfHermitianFFTImageFilterTest double
   )
 _vkfft_disable_on_unsupported_fp64(itkVkHalfHermitianFFTImageFilterTestDouble)
+
+itk_add_test(NAME itkVkHalfHermitianFFTImageFilterTestFloatPoclSafe
+  COMMAND VkFFTBackendTestDriver itkVkHalfHermitianFFTImageFilterTest float 16
+  )
+itk_add_test(NAME itkVkHalfHermitianFFTImageFilterTestDoublePoclSafe
+  COMMAND VkFFTBackendTestDriver itkVkHalfHermitianFFTImageFilterTest double 16
+  )
+_vkfft_disable_on_unsupported_fp64(itkVkHalfHermitianFFTImageFilterTestDoublePoclSafe)
 
 # -----------------------------------------------------------------------------
 # FFTImageFilterFactoryTest (instantiation only — runs on all platforms)
@@ -356,7 +383,7 @@ if(VKFFT_BACKEND EQUAL 4 AND NOT VkFFTBackend_LEVEL_ZERO_RUNTIME_AVAILABLE)
     itkVkDiscreteGaussianImageFilterTest
     itkVkDiscreteGaussianImageFilterTest2
   )
-    foreach(_suffix Float Double)
+    foreach(_suffix Float Double FloatPoclSafe DoublePoclSafe)
       if(TEST ${_stem}${_suffix})
         set_tests_properties(${_stem}${_suffix} PROPERTIES DISABLED TRUE)
       endif()

--- a/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
+++ b/test/itkVkForwardInverse1DFFTImageFilterTest.cxx
@@ -57,7 +57,7 @@ public:
 
 template <typename PrecisionType>
 int
-runVkForwardInverse1DFFTImageFilterTest()
+runVkForwardInverse1DFFTImageFilterTest(unsigned int maxSize = 20)
 {
   int  testNumber{ 0 };
   bool testsPassed{ true };
@@ -72,7 +72,7 @@ runVkForwardInverse1DFFTImageFilterTest()
     bool                              firstPass{ true };
 
     // Skip trivial case where 1D image of size 1 fails.
-    for (unsigned int mySize{ 2 }; mySize <= 20; ++mySize)
+    for (unsigned int mySize{ 2 }; mySize <= maxSize; ++mySize)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -184,14 +184,15 @@ runVkForwardInverse1DFFTImageFilterTest()
 int
 itkVkForwardInverse1DFFTImageFilterTest(int argc, char * argv[])
 {
-  const std::string precision{ (argc > 1) ? argv[1] : "float" };
+  const std::string  precision{ (argc > 1) ? argv[1] : "float" };
+  const unsigned int maxSize{ (argc > 2) ? static_cast<unsigned int>(std::stoul(argv[2])) : 20 };
   if (precision == "double")
   {
-    return runVkForwardInverse1DFFTImageFilterTest<double>();
+    return runVkForwardInverse1DFFTImageFilterTest<double>(maxSize);
   }
   if (precision == "float")
   {
-    return runVkForwardInverse1DFFTImageFilterTest<float>();
+    return runVkForwardInverse1DFFTImageFilterTest<float>(maxSize);
   }
   std::cerr << "Unknown precision '" << precision << "'. Expected 'float' or 'double'." << std::endl;
   return EXIT_FAILURE;

--- a/test/itkVkForwardInverseFFTImageFilterTest.cxx
+++ b/test/itkVkForwardInverseFFTImageFilterTest.cxx
@@ -57,7 +57,7 @@ public:
 
 template <typename PrecisionType>
 int
-runVkForwardInverseFFTImageFilterTest()
+runVkForwardInverseFFTImageFilterTest(unsigned int maxSize = 20)
 {
   int  testNumber{ 0 };
   bool testsPassed{ true };
@@ -72,7 +72,7 @@ runVkForwardInverseFFTImageFilterTest()
     bool                              firstPass{ true };
 
     // Skip trivial case where 1D image of size 1 fails.
-    for (unsigned int mySize{ 2 }; mySize <= 20; ++mySize, firstPass = false)
+    for (unsigned int mySize{ 2 }; mySize <= maxSize; ++mySize, firstPass = false)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -185,14 +185,15 @@ runVkForwardInverseFFTImageFilterTest()
 int
 itkVkForwardInverseFFTImageFilterTest(int argc, char * argv[])
 {
-  const std::string precision{ (argc > 1) ? argv[1] : "float" };
+  const std::string  precision{ (argc > 1) ? argv[1] : "float" };
+  const unsigned int maxSize{ (argc > 2) ? static_cast<unsigned int>(std::stoul(argv[2])) : 20 };
   if (precision == "double")
   {
-    return runVkForwardInverseFFTImageFilterTest<double>();
+    return runVkForwardInverseFFTImageFilterTest<double>(maxSize);
   }
   if (precision == "float")
   {
-    return runVkForwardInverseFFTImageFilterTest<float>();
+    return runVkForwardInverseFFTImageFilterTest<float>(maxSize);
   }
   std::cerr << "Unknown precision '" << precision << "'. Expected 'float' or 'double'." << std::endl;
   return EXIT_FAILURE;

--- a/test/itkVkHalfHermitianFFTImageFilterTest.cxx
+++ b/test/itkVkHalfHermitianFFTImageFilterTest.cxx
@@ -57,7 +57,7 @@ public:
 
 template <typename PrecisionType>
 int
-runVkHalfHermitianFFTImageFilterTest()
+runVkHalfHermitianFFTImageFilterTest(unsigned int maxSize = 20)
 {
   int  testNumber{ 0 };
   bool testsPassed{ true };
@@ -71,7 +71,7 @@ runVkHalfHermitianFFTImageFilterTest()
     typename RealImageType::IndexType index;
     bool                              firstPass{ true };
     // Skip trivial case where 1D image of size 1 fails.
-    for (unsigned int mySize{ 2 }; mySize <= 20; ++mySize, firstPass = false)
+    for (unsigned int mySize{ 2 }; mySize <= maxSize; ++mySize, firstPass = false)
     {
       // We expect that anything evenly divisible by a prime number greater than 13
       // will succeed with Bluestein's Algorithm implementation in VkFFT, though
@@ -189,14 +189,15 @@ runVkHalfHermitianFFTImageFilterTest()
 int
 itkVkHalfHermitianFFTImageFilterTest(int argc, char * argv[])
 {
-  const std::string precision{ (argc > 1) ? argv[1] : "float" };
+  const std::string  precision{ (argc > 1) ? argv[1] : "float" };
+  const unsigned int maxSize{ (argc > 2) ? static_cast<unsigned int>(std::stoul(argv[2])) : 20 };
   if (precision == "double")
   {
-    return runVkHalfHermitianFFTImageFilterTest<double>();
+    return runVkHalfHermitianFFTImageFilterTest<double>(maxSize);
   }
   if (precision == "float")
   {
-    return runVkHalfHermitianFFTImageFilterTest<float>();
+    return runVkHalfHermitianFFTImageFilterTest<float>(maxSize);
   }
   std::cerr << "Unknown precision '" << precision << "'. Expected 'float' or 'double'." << std::endl;
   return EXIT_FAILURE;

--- a/wrapping/dockcross-manylinux-build-module-wheels-opencl.sh
+++ b/wrapping/dockcross-manylinux-build-module-wheels-opencl.sh
@@ -14,9 +14,12 @@
 # Generate dockcross scripts
 
 MANYLINUX_VERSION=${MANYLINUX_VERSION:=_2_28}
-IMAGE_TAG=${IMAGE_TAG:=20221108-102ebcc}
-OPENCL_ICD_LOADER_TAG=v2021.04.29
-OPENCL_HEADERS_TAG=v2021.04.29
+# Match ITKPythonPackage v6.0b02's dockcross image, which ships a recent
+# enough `python -m build` to accept --verbose (the older 20221108 image
+# fails with "unrecognized arguments: --verbose").
+IMAGE_TAG=${IMAGE_TAG:=20260203-3dfb3ff}
+OPENCL_ICD_LOADER_TAG=${OPENCL_ICD_LOADER_TAG:=v2025.07.22}
+OPENCL_HEADERS_TAG=${OPENCL_HEADERS_TAG:=v2025.07.22}
 
 docker run --rm dockcross/manylinux${MANYLINUX_VERSION}-x64:${IMAGE_TAG} > /tmp/dockcross-manylinux-x64
 chmod u+x /tmp/dockcross-manylinux-x64
@@ -49,10 +52,22 @@ if ! test -d ./OpenCL-ICD-Loader; then
 fi
 
 # Build wheels
+#
+# Resolve the actual versioned libOpenCL.so filename produced by the
+# OpenCL-ICD-Loader build. v2021.04.29 produced libOpenCL.so.1.2; the
+# v2025.07.22 build produces libOpenCL.so.1.0.0. Bind-mount whichever the
+# loader actually wrote.
+OPENCL_SO=$(ls $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.* 2>/dev/null | head -1)
+if [[ -z "${OPENCL_SO}" ]]; then
+  echo "ERROR: could not find OpenCL-ICD-Loader-build/libOpenCL.so.1.* — did the loader build?" >&2
+  exit 1
+fi
+echo "Using OpenCL loader: ${OPENCL_SO}"
+
 DOCKER_ARGS="-v $(pwd)/dist:/work/dist/ -v $script_dir/../ITKPythonPackage:/ITKPythonPackage -v $(pwd)/tools:/tools"
 DOCKER_ARGS+=" -v $(pwd)/OpenCL-ICD-Loader/inc/CL:/usr/include/CL"
-DOCKER_ARGS+=" -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so.1"
-DOCKER_ARGS+=" -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so"
+DOCKER_ARGS+=" -v ${OPENCL_SO}:/usr/lib64/libOpenCL.so.1"
+DOCKER_ARGS+=" -v ${OPENCL_SO}:/usr/lib64/libOpenCL.so"
 DOCKER_ARGS+=" -e MANYLINUX_VERSION"
 
 /tmp/dockcross-manylinux-x64 \


### PR DESCRIPTION
Recovers the CI modernization from #74, which was marked **MERGED** but never actually reached `main`. Rebased onto current `main` (preserving the #76 direction-axis test) so the work is not lost.

<details>
<summary>What happened to #74</summary>

#74 (`ci/itk-5.4.6`) was opened against **#73's branch** (`enh/vkfft-backend-5-metal`), not `main`, and was merged into that branch on 2026-06-03 (merge commit `9936e83`).

Before #73 itself merged, its branch was **force-pushed backward** (`9936e83` → `30b8bbe`), which dropped #74's seven commits from the branch tip. When #73 subsequently merged into `main`, it carried the `30b8bbe` state — **without** any of #74's changes.

The result: GitHub still shows #74 as "MERGED" (it was merged into the branch), but none of its commits are ancestors of `main`. Verify:

```
# 9936e83 (the #74 merge) is NOT in main:
git merge-base --is-ancestor 9936e83abb92a27b5ca174add6c5f0af415f0b01 origin/main; echo $?   # -> 1
# main still has the pre-#74 tags:
git show origin/main:.github/workflows/build-test-package.yml | grep -E 'itk-git-tag|opencl-.*-git-tag'
#   itk-git-tag: "v5.3.0"
#   opencl-icd-loader-git-tag: "v2021.04.29"
#   opencl-headers-git-tag:    "v2021.04.29"
```

The branch ref was deleted, but the commits remained reachable via `refs/pull/74/head` and were recovered from there.

</details>

<details>
<summary>What this PR restores (the seven #74 commits, rebased onto main)</summary>

- ITK `v5.4.6` (`itk-git-tag` / `itk-wheel-tag`), runners on `macos-15`
- OpenCL ICD-Loader and Headers `v2025.07.22`; target OpenCL 3.0 (`CL_TARGET_OPENCL_VERSION=300`)
- macOS PoCL via Homebrew; Linux PoCL via conda-forge (with Anaconda ToS accept)
- Device-less OpenCL hardening (`itkVkCommon.cxx`, `itk-module-init.cmake`, `itkVkDefinitions.h`)
- Compile-only build matrix for CUDA / Level Zero / Metal backends
- Self-hosted GPU workflows gated behind `workflow_dispatch` / the `gpu-ci` label
- Minimal-ITK-modules build to speed CI; a PoCL-safe FFT round-trip subset on the hosted OpenCL leg

The rebase preserved #76's direction-axis test (`itkVkComplexToComplex1DFFTImageFilterSizesTest.cxx`) unchanged — #74 never modified that file.

</details>

<!--
provenance: recovered via refs/pull/74/head; rebased onto origin/main (a519718).
lost-merge: 9936e83 (PR#74 into PR#73 branch) reverted by force-push 9936e83->30b8bbe before #73 merged.
note: largely supersedes the CI-repair commit on PR #77; once this lands, #77 can drop that commit and rebase to be validated by the recovered CI.
-->
