### PR TITLE
COMP: Pin mutable CI action references to fixed versions

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -68,7 +68,7 @@ jobs:
         python -m pip install ninja
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@v4.3.3
 
     - name: Download OpenCL-SDK
       if: matrix.os == 'macos-15'
@@ -321,11 +321,11 @@ jobs:
       shell: bash
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@v4.3.3
 
     - name: Install CUDA toolkit
       if: matrix.backend == 1
-      uses: Jimver/cuda-toolkit@v0.2.21
+      uses: Jimver/cuda-toolkit@v0.2.35
       with:
         method: network
         sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev"]'
@@ -409,7 +409,7 @@ jobs:
 
     steps:
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@v4.3.3
 
     - uses: actions/checkout@v5
       with:
@@ -551,7 +551,7 @@ jobs:
         sudo xcode-select -s "${XCODE_APP}/Contents/Developer"
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@v4.3.3
 
     - name: 'Fetch build script'
       run: |
@@ -602,7 +602,7 @@ jobs:
 
     - name: Publish 🐍 Python 📦 package to PyPI
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.14.0
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@main
+    - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@bab3a0bb26af8a23c7cc2c1d4265834415089eb5 # main
       with:
         itk-branch: main

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@v4.3.3
 
     - name: Download OpenCL-ICD-Loader
       run: |

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash
 
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
Pin the remaining floating/mutable GitHub Actions references to fixed versions so CI is reproducible and not silently affected by upstream action changes. Pure CI hygiene — no source or build-logic changes.

The highest-value fix is **`pypa/gh-action-pypi-publish@master` → `@v1.14.0`**: that action runs the credentialed PyPI publish (`user: __token__`), so a moving branch ref is the riskiest reference in the tree.

<details>
<summary>All changes (6 refs across 4 workflows)</summary>

| File | Before | After |
|---|---|---|
| build-test-package.yml | `pypa/gh-action-pypi-publish@master` | `@v1.14.0` |
| build-test-package.yml | `lukka/get-cmake@latest` (×4) | `@v4.3.3` |
| build-test-package.yml | `Jimver/cuda-toolkit@v0.2.21` | `@v0.2.35` |
| test-gpu.yml | `lukka/get-cmake@v3.22.2` | `@v4.3.3` |
| clang-format-linter.yml | `ITKClangFormatLinterAction@main` | `@bab3a0bb26af8a23c7cc2c1d4265834415089eb5` (SHA; action has no release tags) |
| test-notebooks.yml | `actions/setup-python@v3` | `@v5` |

- `get-cmake@v4.3.3` is the release `@latest` currently resolves to, so the four `@latest` swaps are behavior-preserving.
- `get-cmake@v3.22.2` in test-gpu.yml bundles an `@actions/cache` that calls the retired Actions cache API and aborts fatally; dormant only because that job is gated. Unified to `@v4.3.3`.
- All pin targets verified as published releases.

</details>

<details>
<summary>Validation</summary>

Workflow files can only be exercised by CI itself (no local run). All four YAML files parse, no mutable/stale refs remain, and `pre-commit run --all-files` passes on the branch.

</details>

<!--
provenance: claude-code session 2026-06-08
branch: comp/ci-pin-action-refs off main @20b86e4 (post #80 merge)
related: follow-up to #80 (CUDA cleanup + formatting); CI workflows originally landed via #79.
resolved_versions: get-cmake v4.3.3 (latest), gh-action-pypi-publish v1.14.0 (latest),
  cuda-toolkit v0.2.35 (latest), ITKClangFormatLinterAction main@bab3a0bb26af8a23c7cc2c1d4265834415089eb5 (no tags).
-->
