### PR TITLE
COMP: Make the CUDA (VKFFT_BACKEND=1) backend installable and consumable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,23 @@ add_compile_definitions(VKFFT_BACKEND=${VKFFT_BACKEND})
 if(VKFFT_BACKEND EQUAL 1)
   find_package(CUDAToolkit REQUIRED)
   list(APPEND VkFFTBackend_SYSTEM_INCLUDE_DIRS ${CUDAToolkit_INCLUDE_DIRS})
+
+  ## When this module is loaded by an app, resolve the CUDA imported targets
+  ## (CUDA::cudart, CUDA::cuda_driver, ...) referenced in its link interface.
+  set(
+    VkFFTBackend_EXPORT_CODE_INSTALL
+    "
+  find_package(CUDAToolkit REQUIRED)
+  "
+  )
+  set(
+    VkFFTBackend_EXPORT_CODE_BUILD
+    "
+  if(NOT ITK_BINARY_DIR)
+    find_package(CUDAToolkit REQUIRED)
+  endif()
+  "
+  )
 elseif(VKFFT_BACKEND EQUAL 3)
   set(
     CL_TARGET_OPENCL_VERSION

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,15 +9,15 @@ itk_module_add_library(VkFFTBackend ${VkFFTBackend_SRCS})
 
 if(${VKFFT_BACKEND} EQUAL 1)
   # itkVkCommon.cxx is host code; VkFFT JIT-compiles CUDA kernels at runtime
-  # via nvrtc, so no nvcc device compilation is required here.
+  # via nvrtc, so no nvcc device compilation is required here. VkFFT and half
+  # are header-only; their include dirs arrive via VkFFTBackend_SYSTEM_INCLUDE_DIRS
+  # (as for the OpenCL backend), so only the CUDA libraries are linked.
   target_link_libraries(
     VkFFTBackend
     PUBLIC
       ${CUDA_LIBRARIES}
       CUDA::cuda_driver
       ${CUDA_NVRTC_LIB}
-      VkFFT
-      half
   )
 elseif(${VKFFT_BACKEND} EQUAL 3)
   target_link_libraries(VkFFTBackend PUBLIC ${OpenCL_LIBRARY})


### PR DESCRIPTION
Two issues prevented building ITK with the CUDA backend (`VKFFT_BACKEND=1`) from generating, and prevented a downstream `find_package(ITK)` from consuming it. The OpenCL backend already handles both correctly; this brings the CUDA branch in line.

<details>
<summary>1. <code>install(EXPORT)</code> failure — header-only targets in the link interface</summary>

`src/CMakeLists.txt` (backend 1) linked the header-only `VkFFT` and `half` **targets** PUBLIC:

```cmake
target_link_libraries(VkFFTBackend PUBLIC ${CUDA_LIBRARIES} CUDA::cuda_driver ${CUDA_NVRTC_LIB} VkFFT half)
```

Those targets are not part of ITK's export set, so `install(EXPORT ITKTargets)` fails generation:

```
install(EXPORT "ITKTargets" ...) includes target "VkFFTBackend" which
requires target "VkFFT" that is not in any export set.
```

and a build-tree consumer (`ITK_DIR` pointing at the build tree) gets an unresolvable `-lVkFFT -lhalf` link line. The **OpenCL** backend links neither — `VkFFT`/`half` are header-only and their include dirs already arrive via `VkFFTBackend_SYSTEM_INCLUDE_DIRS`. Fix: drop the two header-only targets, link only the CUDA runtime/driver/nvrtc libraries.

</details>

<details>
<summary>2. No <code>find_dependency(CUDAToolkit)</code> in the exported config</summary>

The backend-1 branch set no `VkFFTBackend_EXPORT_CODE_{BUILD,INSTALL}` (the OpenCL and Level Zero branches do). VkFFTBackend's link interface references the `CUDA::cudart` imported target, so a downstream `find_package(ITK)` fails unless the consumer itself calls `find_package(CUDAToolkit)`:

```
The link interface of target "ITK::VkFFTBackend" contains:
  CUDA::cudart
but the target was not found.
```

Fix: emit `find_package(CUDAToolkit)` into the exported build/install config, mirroring the OpenCL backend's `find_package(OpenCL)`.

</details>

<details>
<summary>Validation</summary>

- Built ITK `main` with `Module_VkFFTBackend=ON -DVKFFT_BACKEND=1` (CUDA 13.2, VkFFT JIT-compiles kernels via nvrtc — no nvcc device compilation, so no GPU-arch concerns).
- Consumed the result from a separate project with **no** `find_package(CUDAToolkit)` of its own: configure + build now succeed (previously failed at both generate and consume).
- Ran an FFT round-trip on an RTX 6000 Ada (sm_89): executes on the GPU, round-trip error 0.000.
- `pre-commit run --all-files` clean (gersemi).

CMake-only change; no new tests.

</details>

<!--
provenance: found 2026-06-17 enabling VkFFT CUDA backend for ANTs (ANTsX/ANTs#1331)
files: CMakeLists.txt (backend-1 export code), src/CMakeLists.txt (drop VkFFT/half target links)
companion: ITK PR InsightSoftwareConsortium/ITK#6465 (build-tree SYSTEM_INCLUDE_DIRS BUILD_INTERFACE wrap)
still_open: itkVkCommon.cxx creates+leaks a GPU context/queue per Update() (OpenCL & CUDA) -> OOM under sustained use; needs context/plan caching (separate, larger change).
-->
